### PR TITLE
Initial work to publish to maven central

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # Sensitive or high-churn files:
 # IntelliJ
 /out/
+bin
 build
 
 /website/node_modules

--- a/build.gradle
+++ b/build.gradle
@@ -1,24 +1,53 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+        url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:5.1.0'
+        classpath "de.marcphilipp.gradle:nexus-publish-plugin:0.3.0"
     }
 }
 
-version = '1.1'
+plugins {
+    id 'io.codearte.nexus-staging' version '0.21.0'
+}
+
+allprojects {
+    version = '1.1-SNAPSHOT'
+}
 
 subprojects {
     apply plugin: 'java'
+    apply plugin: 'maven-publish'
+    apply plugin: 'de.marcphilipp.nexus-publish'
 
     repositories {
         mavenCentral()
     }
+
+    group = 'org.openapitools.openapistylevalidator'
 
     dependencies {
         compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
         compile group: 'org.slf4j', name: 'slf4j-jdk14', version: '1.7.25'
         testCompile group: 'junit', name: 'junit', version: '4.12'
     }
+
+    nexusPublishing {
+        repositories {
+            sonatype {
+                username = project.findProperty('sonatypeUser') ?: ''
+                password = project.findProperty('sonatypePassword') ?: ''
+            }
+        }
+    }
+}
+
+nexusStaging {
+    packageGroup = 'org.openapitools'
+    username = project.findProperty('sonatypeUser') ?: ''
+    password = project.findProperty('sonatypePassword') ?: ''
 }

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -20,3 +20,53 @@ shadowJar {
 }
 
 project.tasks.assemble.dependsOn project.tasks.shadowJar
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar) {
+    from javadoc
+    classifier = 'javadoc'
+}
+
+artifacts {
+	archives shadowJar
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = 'openapi-style-validator-cli'
+            pom {
+                name = 'OpenAPI Style Validator - cli'
+                description = 'Command line interface to validate the style and standards of an OpenAPI specification'
+                packaging = 'jar'
+                url = 'https://openapitools.github.io/openapi-style-validator/'
+                licenses {
+                    license {
+                        name = 'Apache 2.0 License'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'JFCote'
+                        name = 'Jean-Francois Cote'
+                        email = 'jcote@stingray.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:https://github.com/openapitools/openapi-style-validator.git'
+                    developerConnection = 'scm:git:https://github.com/openapitools/openapi-style-validator.git'
+                    url = 'https://github.com/openapitools/openapi-style-validator/'
+                }
+            }
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+            artifact shadowJar
+        }
+    }
+}

--- a/cli/src/main/java/org/openapitools/openapistylevalidator/Main.java
+++ b/cli/src/main/java/org/openapitools/openapistylevalidator/Main.java
@@ -14,7 +14,7 @@ import org.openapitools.openapistylevalidator.styleerror.StyleError;
 
 import java.util.List;
 
-class Main {
+public class Main {
 
     private static final String SOURCE_OPT_SHORT = "s";
     private static final String SOURCE_OPT_LONG = "source";

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -2,3 +2,48 @@ dependencies {
   compile group: 'org.eclipse.microprofile.openapi', name: 'microprofile-openapi-api', version: '2.0-MR1'
   compile group: 'com.google.code.gson', name: 'gson', version: '2.8.1'
 }
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar) {
+    from javadoc
+    classifier = 'javadoc'
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = 'openapi-style-validator-lib'
+            pom {
+                name = 'OpenAPI Style Validator - lib'
+                description = 'Library to validate the style and standards of an OpenAPI specification'
+                packaging = 'jar'
+                url = 'https://openapitools.github.io/openapi-style-validator/'
+                licenses {
+                    license {
+                        name = 'Apache 2.0 License'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'JFCote'
+                        name = 'Jean-Francois Cote'
+                        email = 'jcote@stingray.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:https://github.com/openapitools/openapi-style-validator.git'
+                    developerConnection = 'scm:git:https://github.com/openapitools/openapi-style-validator.git'
+                    url = 'https://github.com/openapitools/openapi-style-validator/'
+                }
+            }
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+        }
+    }
+}


### PR DESCRIPTION
See issue #10

With this changes it is possible to publish to maven local:

```
./gradlew publishToMavenLocal
```

It produces the expected tree:
```
~/.m2/repository/org/openapitools/openapistylevalidator/
├── openapi-style-validator-cli
│   ├── 1.1-SNAPSHOT
│   │   ├── maven-metadata-local.xml
│   │   ├── openapi-style-validator-cli-1.1-SNAPSHOT-all.jar
│   │   ├── openapi-style-validator-cli-1.1-SNAPSHOT-javadoc.jar
│   │   ├── openapi-style-validator-cli-1.1-SNAPSHOT-sources.jar
│   │   ├── openapi-style-validator-cli-1.1-SNAPSHOT.jar
│   │   └── openapi-style-validator-cli-1.1-SNAPSHOT.pom
│   └── maven-metadata-local.xml
└── openapi-style-validator-lib
    ├── 1.1-SNAPSHOT
    │   ├── maven-metadata-local.xml
    │   ├── openapi-style-validator-lib-1.1-SNAPSHOT-javadoc.jar
    │   ├── openapi-style-validator-lib-1.1-SNAPSHOT-sources.jar
    │   ├── openapi-style-validator-lib-1.1-SNAPSHOT.jar
    │   └── openapi-style-validator-lib-1.1-SNAPSHOT.pom
    └── maven-metadata-local.xml
```

---

With this change, we should be able to publish to https://oss.sonatype.org/content/repositories/snapshots/

If you agree with this PR, I would like to push a first SNAPSHOT from my computer and then configure Travis-CI to do it.

---

NOTE: To create a release an push it on maven central, more work is requested: we need to sign the artifacts correctly.
For `openapi-style-validator-lib` this is straight forward. For `openapi-style-validator-cli`, I did not manage to produce the correct `.asc` files and to publish them correctly.