### PR TITLE
Travis: add publishToSonatype step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 before_install:
  - chmod +x gradlew
  
+script: ./gradlew build
 language: java
 jdk:
   - openjdk8
@@ -8,3 +9,10 @@ jdk:
   - openjdk10
   - openjdk11
   - openjdk12
+
+jobs:
+  include:
+    - stage: deploy
+      if: env(SONATYPE_USERNAME) IS present AND type IN (push, api) AND branch IN (master) AND tag IS blank
+      jdk: openjdk8
+      script: ./gradlew publishToSonatype -PsonatypeUser=$SONATYPE_USER -PsonatypePassword=$SONATYPE_PASSWORD


### PR DESCRIPTION
As discussed in #29, I think it would be great to have a job to execute `publishToSonatype` (running with Java 8).

This will push the SNAPSHOT versions to https://oss.sonatype.org/content/repositories/

I have added the corresponding config in Travis UI.