### PR TITLE
Fix #36 cli version

### DIFF
--- a/.idea/modules/cli/cli_main.iml
+++ b/.idea/modules/cli/cli_main.iml
@@ -11,6 +11,15 @@
     <orderEntry type="module" module-name="lib_main" />
     <orderEntry type="library" name="Gradle: org.slf4j:slf4j-jdk14:1.7.25" level="project" />
     <orderEntry type="library" name="Gradle: io.swagger.parser.v3:swagger-parser:2.0.14" level="project" />
+    <orderEntry type="module-library" scope="RUNTIME">
+      <library>
+        <CLASSES>
+          <root url="file://$MODULE_DIR$/../../../cli/build/generated-version" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
     <orderEntry type="library" name="Gradle: io.swagger.parser.v3:swagger-parser-v2-converter:2.0.14" level="project" />
     <orderEntry type="library" name="Gradle: io.swagger:swagger-compat-spec-parser:1.0.46" level="project" />
     <orderEntry type="library" name="Gradle: io.swagger:swagger-parser:1.0.46" level="project" />

--- a/.idea/modules/cli/cli_test.iml
+++ b/.idea/modules/cli/cli_test.iml
@@ -7,6 +7,15 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="cli_main" />
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="file://$MODULE_DIR$/../../../cli/build/generated-version" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
     <orderEntry type="module" module-name="lib_main" />
     <orderEntry type="library" name="Gradle: org.slf4j:slf4j-jdk14:1.7.25" level="project" />
     <orderEntry type="library" name="Gradle: io.swagger.parser.v3:swagger-parser:2.0.14" level="project" />

--- a/.idea/runConfigurations/Run_version.xml
+++ b/.idea/runConfigurations/Run_version.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run version" type="Application" factoryName="Application">
+    <option name="ALTERNATIVE_JRE_PATH" value="1.8" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="MAIN_CLASS_NAME" value="org.openapitools.openapistylevalidator.Main" />
+    <module name="cli_main" />
+    <option name="PROGRAM_PARAMETERS" value="-v" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -12,6 +12,25 @@ mainClassName = 'org.openapitools.openapistylevalidator.Main'
 
 apply plugin: 'com.github.johnrengelman.shadow'
 
+def generatedVersionDir = "${buildDir}/generated-version"
+
+sourceSets {
+    main {
+        output.dir(generatedVersionDir, builtBy: 'generateVersionProperties')
+    }
+}
+
+task generateVersionProperties {
+    doLast {
+        def propertiesFile = file "$generatedVersionDir/version.properties"
+        propertiesFile.parentFile.mkdirs()
+        def properties = new Properties()
+        properties.setProperty("version", rootProject.version.toString())
+        propertiesFile.withWriter { properties.store(it, null) }
+    }
+}
+processResources.dependsOn generateVersionProperties
+
 shadowJar {
 	//noinspection GroovyAccessibility
     archiveBaseName = "openapi-style-validator-cli"

--- a/cli/src/main/java/org/openapitools/openapistylevalidator/OutputUtils.java
+++ b/cli/src/main/java/org/openapitools/openapistylevalidator/OutputUtils.java
@@ -4,8 +4,11 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.openapitools.openapistylevalidator.styleerror.StyleError;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
 import java.util.List;
+import java.util.Properties;
 
 class OutputUtils {
 
@@ -39,7 +42,14 @@ class OutputUtils {
     }
 
     private String getVersion() {
-        String tentativeVersion = getClass().getPackage().getImplementationVersion();
-        return tentativeVersion == null ? "DEVELOPMENT" : tentativeVersion;
+        try (InputStream input = OutputUtils.class.getResourceAsStream("/version.properties")) {
+            if (input != null) {
+                Properties prop = new Properties();
+                prop.load(input);
+                return prop.getProperty("version");
+            }
+        } catch (IOException ignored) { }
+
+        return "No version | Running in the IDE?";
     }
 }


### PR DESCRIPTION
This returns the version by creating a property file at compilation time and putting it in the classpath. Seems to be the recommended solution.

Of course, when launching in the ID, if there is no gradle build, the option will return this: `No version | Running in the IDE?`