### PR TITLE
Improve gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,19 +32,21 @@ subprojects {
 
     group = 'org.openapitools.openapistylevalidator'
 
-    model {
-        tasks.publishMavenJavaPublicationToMavenLocal {
-            dependsOn(project.tasks.signArchives)
-        }
-        tasks.publishMavenJavaPublicationToSonatypeRepository {
-            dependsOn(project.tasks.signArchives)
-        }
-    }
-
     dependencies {
         compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
         compile group: 'org.slf4j', name: 'slf4j-jdk14', version: '1.7.25'
         testCompile group: 'junit', name: 'junit', version: '4.12'
+    }
+
+    signing {
+        useGpgCmd()
+        sign(publishing.publications)
+    }
+
+    tasks.withType(Sign) {
+        onlyIf {
+            project.hasProperty('signing.gnupg.keyName')
+        }
     }
 
     nexusPublishing {

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -50,23 +50,6 @@ task javadocJar(type: Jar) {
     classifier = 'javadoc'
 }
 
-artifacts {
-    archives sourcesJar
-    archives javadocJar
-	archives shadowJar
-}
-
-signing {
-    useGpgCmd()
-    sign configurations.archives
-}
-
-tasks.withType(Sign) {
-    onlyIf {
-        project.hasProperty('signing.gnupg.keyName')
-    }
-}
-
 publishing {
     publications {
         mavenJava(MavenPublication) {
@@ -76,6 +59,7 @@ publishing {
                 description = 'Command line interface to validate the style and standards of an OpenAPI specification'
                 packaging = 'jar'
                 url = 'https://openapitools.github.io/openapi-style-validator/'
+                inceptionYear = "2019"
                 licenses {
                     license {
                         name = 'Apache 2.0 License'
@@ -99,38 +83,6 @@ publishing {
             artifact sourcesJar
             artifact javadocJar
             artifact shadowJar
-
-            if(project.hasProperty('signing.gnupg.keyName')) {
-                pom.withXml {
-                    def pomFile = file("${project.buildDir}/generated-pom.xml")
-                    writeTo(pomFile)
-                    def pomAscFile = signing.sign(pomFile).signatureFiles[0]
-                    artifact(pomAscFile) {
-                        classifier = null
-                        extension = 'pom.asc'
-                    }
-                    pomFile.delete()
-                }
-    
-                project.tasks.signArchives.signatureFiles.each {
-                    if(it.parentFile.name == 'libs') {   
-                        artifact(it) {
-                            def matcher = it.file =~ /-(sources|javadoc)\.jar\.asc$/
-                            if (matcher.find()) {
-                                classifier = matcher.group(1)
-                            } else {
-                                if(it.file.name.startsWith('openapi-style-validator-cli')) {
-                                    //this is the shadowJar, use the 'all' classifier:
-                                    classifier = 'all'
-                                } else {
-                                    classifier = null
-                                }
-                            }
-                            extension = 'jar.asc'
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -14,22 +14,6 @@ task javadocJar(type: Jar) {
     classifier = 'javadoc'
 }
 
-artifacts {
-    archives sourcesJar
-    archives javadocJar
-}
-
-signing {
-    useGpgCmd()
-    sign configurations.archives
-}
-
-tasks.withType(Sign) {
-    onlyIf {
-        project.hasProperty('signing.gnupg.keyName')
-    }
-}
-
 publishing {
     publications {
         mavenJava(MavenPublication) {
@@ -39,6 +23,7 @@ publishing {
                 description = 'Library to validate the style and standards of an OpenAPI specification'
                 packaging = 'jar'
                 url = 'https://openapitools.github.io/openapi-style-validator/'
+                inceptionYear = "2019"
                 licenses {
                     license {
                         name = 'Apache 2.0 License'
@@ -61,31 +46,6 @@ publishing {
             from components.java
             artifact sourcesJar
             artifact javadocJar
-
-            if(project.hasProperty('signing.gnupg.keyName')) {
-                pom.withXml {
-                    def pomFile = file("${project.buildDir}/generated-pom.xml")
-                    writeTo(pomFile)
-                    def pomAscFile = signing.sign(pomFile).signatureFiles[0]
-                    artifact(pomAscFile) {
-                        classifier = null
-                        extension = 'pom.asc'
-                    }
-                    pomFile.delete()
-                }
-    
-                project.tasks.signArchives.signatureFiles.each {
-                    artifact(it) {
-                        def matcher = it.file =~ /-(sources|javadoc)\.jar\.asc$/
-                        if (matcher.find()) {
-                            classifier = matcher.group(1)
-                        } else {
-                            classifier = null
-                        }
-                        extension = 'jar.asc'
-                    }
-                }
-            }
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,4 @@
-include ":cli", ":lib"
+rootProject.name = 'openapi-style-validator'
+
+include ":lib"
+include ":cli"


### PR DESCRIPTION
* Use `sign(publishing.publications)` instead of `sign(configurations.archives)`
* Remove addition to archives
* Remove custom code to sign the generated `*.pom` files and to add them to the publication
* Remove custom code to add the `*.asc` files to the publication
* Remove the task ordering change in the model (dependsOn signArchives)
* Move configuration to the main `build.gradle` (in the `subprojects` section) to avoid repetition