### PR TITLE
Gradle Build: change dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ subprojects {
 
     dependencies {
         compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
-        compile group: 'org.slf4j', name: 'slf4j-jdk14', version: '1.7.25'
         testCompile group: 'junit', name: 'junit', version: '4.12'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,8 @@ subprojects {
     group = 'org.openapitools.openapistylevalidator'
 
     dependencies {
-        compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
-        testCompile group: 'junit', name: 'junit', version: '4.12'
+        compile 'org.slf4j:slf4j-api:1.7.25'
+        testCompile 'junit:junit:4.12'
     }
 
     signing {

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -3,6 +3,8 @@ apply plugin: 'application'
 dependencies {
 	compile project(':lib')
 	compile group: 'commons-cli', name: 'commons-cli', version: '1.4'
+    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.1'
+    compile group: 'org.slf4j', name: 'slf4j-jdk14', version: '1.7.25'
 
 	compile 'io.swagger.parser.v3:swagger-parser:2.0.14'
 	compile 'org.openapitools.empoa:empoa-swagger-core:1.0.0'

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -2,9 +2,9 @@ apply plugin: 'application'
 
 dependencies {
 	compile project(':lib')
-	compile group: 'commons-cli', name: 'commons-cli', version: '1.4'
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.1'
-    compile group: 'org.slf4j', name: 'slf4j-jdk14', version: '1.7.25'
+	compile 'commons-cli:commons-cli:1.4'
+    compile 'com.google.code.gson:gson:2.8.1'
+    compile 'org.slf4j:slf4j-jdk14:1.7.25'
 
 	compile 'io.swagger.parser.v3:swagger-parser:2.0.14'
 	compile 'org.openapitools.empoa:empoa-swagger-core:1.0.0'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-  compile group: 'org.eclipse.microprofile.openapi', name: 'microprofile-openapi-api', version: '2.0-MR1'
-  compile group: 'com.google.code.gson', name: 'gson', version: '2.8.1'
-  testCompile group: 'org.openapitools.empoa', name: 'empoa-simple-models-impl', version: '1.0.0'
+    compile 'org.eclipse.microprofile.openapi:microprofile-openapi-api:2.0-MR1'
+    testCompile group: 'org.slf4j', name: 'slf4j-jdk14', version: '1.7.25'
+    testCompile group: 'org.openapitools.empoa', name: 'empoa-simple-models-impl', version: '1.0.0'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile 'org.eclipse.microprofile.openapi:microprofile-openapi-api:2.0-MR1'
-    testCompile group: 'org.slf4j', name: 'slf4j-jdk14', version: '1.7.25'
-    testCompile group: 'org.openapitools.empoa', name: 'empoa-simple-models-impl', version: '1.0.0'
+    testCompile 'org.slf4j:slf4j-jdk14:1.7.25'
+    testCompile 'org.openapitools.empoa:empoa-simple-models-impl:1.0.0'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {


### PR DESCRIPTION
Fixes #45

* `gson` is only used in the `cli`
* `slf4j-jdk14` (an implementation for slf4j) is only used:
  -  in `cli` 
  -  in `lib` for tests