### PR TITLE
Update JUnit version to 5.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,8 @@ subprojects {
 
     dependencies {
         compile 'org.slf4j:slf4j-api:1.7.25'
-        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
-        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
+        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
+        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
     }
 
     signing {


### PR DESCRIPTION
Update of the library.
This version is newer and better compatible when running tests inside Eclipse IDE.