### PR TITLE
Add equals and hashCode methods to error models

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     compile 'org.eclipse.microprofile.openapi:microprofile-openapi-api:2.0-MR1'
     testCompile 'org.slf4j:slf4j-jdk14:1.7.25'
     testCompile 'org.openapitools.empoa:empoa-simple-models-impl:1.0.0'
+    testCompile 'nl.jqno.equalsverifier:equalsverifier:3.1.13'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/lib/src/main/java/org/openapitools/openapistylevalidator/styleerror/GenericStyleError.java
+++ b/lib/src/main/java/org/openapitools/openapistylevalidator/styleerror/GenericStyleError.java
@@ -1,6 +1,8 @@
 package org.openapitools.openapistylevalidator.styleerror;
 
-public class GenericStyleError extends StyleError {
+import java.util.Objects;
+
+public final class GenericStyleError extends StyleError {
 
     private final String parentObjectName;
 
@@ -8,6 +10,22 @@ public class GenericStyleError extends StyleError {
         super(styleCheckSection, fieldNames, description);
 
         this.parentObjectName = parentObjectName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GenericStyleError that = (GenericStyleError) o;
+        return styleCheckSection == that.styleCheckSection &&
+                Objects.equals(fieldNames, that.fieldNames) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(parentObjectName, that.parentObjectName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(styleCheckSection, fieldNames, description, parentObjectName);
     }
 
     @Override

--- a/lib/src/main/java/org/openapitools/openapistylevalidator/styleerror/ModelNamingStyleError.java
+++ b/lib/src/main/java/org/openapitools/openapistylevalidator/styleerror/ModelNamingStyleError.java
@@ -1,12 +1,30 @@
 package org.openapitools.openapistylevalidator.styleerror;
 
-public class ModelNamingStyleError extends StyleError {
+import java.util.Objects;
+
+public final class ModelNamingStyleError extends StyleError {
 
     private final String model;
 
     public ModelNamingStyleError(StyleCheckSection styleCheckSection, String fieldNames, String description, String model) {
         super(styleCheckSection, fieldNames, description);
         this.model = model;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ModelNamingStyleError that = (ModelNamingStyleError) o;
+        return styleCheckSection == that.styleCheckSection &&
+                Objects.equals(fieldNames, that.fieldNames) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(model, that.model);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(styleCheckSection, fieldNames, description, model);
     }
 
     @Override

--- a/lib/src/main/java/org/openapitools/openapistylevalidator/styleerror/ModelStyleError.java
+++ b/lib/src/main/java/org/openapitools/openapistylevalidator/styleerror/ModelStyleError.java
@@ -1,6 +1,8 @@
 package org.openapitools.openapistylevalidator.styleerror;
 
-public class ModelStyleError extends StyleError {
+import java.util.Objects;
+
+public final class ModelStyleError extends StyleError {
 
     private final String modelName;
     private final String propertyName;
@@ -13,6 +15,23 @@ public class ModelStyleError extends StyleError {
         this.modelName = modelName;
         this.propertyName = propertyName;
 
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ModelStyleError that = (ModelStyleError) o;
+        return styleCheckSection == that.styleCheckSection &&
+                Objects.equals(fieldNames, that.fieldNames) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(modelName, that.modelName) &&
+                Objects.equals(propertyName, that.propertyName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(styleCheckSection, fieldNames, description, modelName, propertyName);
     }
 
     @Override

--- a/lib/src/main/java/org/openapitools/openapistylevalidator/styleerror/OperationNamingStyleError.java
+++ b/lib/src/main/java/org/openapitools/openapistylevalidator/styleerror/OperationNamingStyleError.java
@@ -2,7 +2,9 @@ package org.openapitools.openapistylevalidator.styleerror;
 
 import org.eclipse.microprofile.openapi.models.PathItem;
 
-public class OperationNamingStyleError extends StyleError {
+import java.util.Objects;
+
+public final class OperationNamingStyleError extends StyleError {
 
     private final String path;
     private final PathItem.HttpMethod method;
@@ -11,6 +13,23 @@ public class OperationNamingStyleError extends StyleError {
         super(styleCheckSection, fieldNames, description);
         this.path = path;
         this.method = method;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OperationNamingStyleError that = (OperationNamingStyleError) o;
+        return styleCheckSection == that.styleCheckSection &&
+                Objects.equals(fieldNames, that.fieldNames) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(path, that.path) &&
+                method == that.method;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(styleCheckSection, fieldNames, description, path, method);
     }
 
     @Override

--- a/lib/src/main/java/org/openapitools/openapistylevalidator/styleerror/OperationStyleError.java
+++ b/lib/src/main/java/org/openapitools/openapistylevalidator/styleerror/OperationStyleError.java
@@ -2,7 +2,9 @@ package org.openapitools.openapistylevalidator.styleerror;
 
 import org.eclipse.microprofile.openapi.models.PathItem;
 
-public class OperationStyleError extends StyleError {
+import java.util.Objects;
+
+public final class OperationStyleError extends StyleError {
 
     private final String path;
     private final PathItem.HttpMethod method;
@@ -15,6 +17,23 @@ public class OperationStyleError extends StyleError {
         this.path = path;
         this.method = method;
 
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OperationStyleError that = (OperationStyleError) o;
+        return styleCheckSection == that.styleCheckSection &&
+                Objects.equals(fieldNames, that.fieldNames) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(path, that.path) &&
+                method == that.method;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(styleCheckSection, fieldNames, description, path, method);
     }
 
     @Override

--- a/lib/src/test/java/org/openapitools/openapistylevalidator/styleerror/GenericStyleErrorTest.java
+++ b/lib/src/test/java/org/openapitools/openapistylevalidator/styleerror/GenericStyleErrorTest.java
@@ -1,0 +1,15 @@
+package org.openapitools.openapistylevalidator.styleerror;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GenericStyleErrorTest {
+    @Test
+    void equalsContract() {
+        EqualsVerifier.forClass(GenericStyleError.class)
+                .withNonnullFields("styleCheckSection", "fieldNames", "description")
+                .verify();
+    }
+}

--- a/lib/src/test/java/org/openapitools/openapistylevalidator/styleerror/ModelNamingStyleErrorTest.java
+++ b/lib/src/test/java/org/openapitools/openapistylevalidator/styleerror/ModelNamingStyleErrorTest.java
@@ -1,0 +1,13 @@
+package org.openapitools.openapistylevalidator.styleerror;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class ModelNamingStyleErrorTest {
+    @Test
+    void equalsContract() {
+        EqualsVerifier.forClass(ModelNamingStyleError.class)
+                .withNonnullFields("styleCheckSection", "fieldNames", "description", "model")
+                .verify();
+    }
+}

--- a/lib/src/test/java/org/openapitools/openapistylevalidator/styleerror/ModelStyleErrorTest.java
+++ b/lib/src/test/java/org/openapitools/openapistylevalidator/styleerror/ModelStyleErrorTest.java
@@ -1,0 +1,13 @@
+package org.openapitools.openapistylevalidator.styleerror;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class ModelStyleErrorTest {
+    @Test
+    void equalsContract() {
+        EqualsVerifier.forClass(ModelStyleError.class)
+                .withNonnullFields("styleCheckSection", "fieldNames", "description", "modelName", "propertyName")
+                .verify();
+    }
+}

--- a/lib/src/test/java/org/openapitools/openapistylevalidator/styleerror/OperationNamingStyleErrorTest.java
+++ b/lib/src/test/java/org/openapitools/openapistylevalidator/styleerror/OperationNamingStyleErrorTest.java
@@ -1,0 +1,13 @@
+package org.openapitools.openapistylevalidator.styleerror;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class OperationNamingStyleErrorTest {
+    @Test
+    void equalsContract() {
+        EqualsVerifier.forClass(OperationNamingStyleError.class)
+                .withNonnullFields("styleCheckSection", "fieldNames", "description", "path")
+                .verify();
+    }
+}

--- a/lib/src/test/java/org/openapitools/openapistylevalidator/styleerror/OperationStyleErrorTest.java
+++ b/lib/src/test/java/org/openapitools/openapistylevalidator/styleerror/OperationStyleErrorTest.java
@@ -1,0 +1,13 @@
+package org.openapitools.openapistylevalidator.styleerror;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class OperationStyleErrorTest {
+    @Test
+    void equalsContract() {
+        EqualsVerifier.forClass(OperationStyleError.class)
+                .withNonnullFields("styleCheckSection", "fieldNames", "description", "path", "method")
+                .verify();
+    }
+}


### PR DESCRIPTION
Having a valid `equals()` and `hashCode()` methods for error models such as `ModelNamingStyleError` enables users to handle the result of `OpenApiSpecStyleValidator#validate(ValidatorParameters parameters)` more easily, for example remove or check for specific error instances.