### PR TITLE
Initial version of the maven-plugin

### DIFF
--- a/cli/src/test/java/org/openapitools/openapistylevalidator/cli/MainTest.java
+++ b/cli/src/test/java/org/openapitools/openapistylevalidator/cli/MainTest.java
@@ -7,13 +7,24 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.openapitools.openapistylevalidator.ValidatorParameters;
+import org.openapitools.openapistylevalidator.ValidatorParameters.NamingConvention;
 import org.openapitools.openapistylevalidator.styleerror.StyleError;
 import org.opentest4j.MultipleFailuresError;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.Objects;
 
 public class MainTest {
-    private static final DefaultParser parser = new DefaultParser();
+	private static final String PREFIX = "    \"";
+	private static final String SEPARATOR = "\": ";
+	private static final String SEPARATOR_QUOTE = "\": \"";
+	private static final String NEXT_LINE = ",\n";
+	private static final String NEXT_LINE_QUOTE = "\",\n";
+	private static final DefaultParser parser = new DefaultParser();
 
     @Test
     void validateShouldReturnSixErrorsWithoutOptionFile() throws Exception {
@@ -128,4 +139,87 @@ public class MainTest {
                 () -> assertEquals("*ERROR* in path /some_path/{some_id} 'some_path' -> path should be in " + expectedPathConvention, errorList.get(2).toString())
                 );
     }
+    
+    @Test
+    void defaultJsonFileContainsConstants() throws Exception {
+        String filePath = Objects.requireNonNull(MainTest.class.getClassLoader().getResource("default.json")).getPath();
+        byte[] bytes = Files.readAllBytes(Paths.get(filePath));
+        String content = new String(bytes, StandardCharsets.UTF_8);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n");
+        sb.append(PREFIX);
+        sb.append(ValidatorParameters.VALIDATE_INFO_LICENSE);
+        sb.append(SEPARATOR);
+        sb.append("true");
+        sb.append(NEXT_LINE);
+        sb.append(PREFIX);
+        sb.append(ValidatorParameters.VALIDATE_INFO_DESCRIPTION);
+        sb.append(SEPARATOR);
+        sb.append("true");
+        sb.append(NEXT_LINE);
+        sb.append(PREFIX);
+        sb.append(ValidatorParameters.VALIDATE_INFO_CONTACT);
+        sb.append(SEPARATOR);
+        sb.append("true");
+        sb.append(NEXT_LINE);
+        sb.append(PREFIX);
+        sb.append(ValidatorParameters.VALIDATE_OPERATION_OPERATION_ID);
+        sb.append(SEPARATOR);
+        sb.append("true");
+        sb.append(NEXT_LINE);
+        sb.append(PREFIX);
+        sb.append(ValidatorParameters.VALIDATE_OPERATION_DESCRIPTION);
+        sb.append(SEPARATOR);
+        sb.append("true");
+        sb.append(NEXT_LINE);
+        sb.append(PREFIX);
+        sb.append(ValidatorParameters.VALIDATE_OPERATION_TAG);
+        sb.append(SEPARATOR);
+        sb.append("true");
+        sb.append(NEXT_LINE);
+        sb.append(PREFIX);
+        sb.append(ValidatorParameters.VALIDATE_OPERATION_SUMMARY);
+        sb.append(SEPARATOR);
+        sb.append("true");
+        sb.append(NEXT_LINE);
+        sb.append(PREFIX);
+        sb.append(ValidatorParameters.VALIDATE_MODEL_PROPERTIES_EXAMPLE);
+        sb.append(SEPARATOR);
+        sb.append("true");
+        sb.append(NEXT_LINE);
+        sb.append(PREFIX);
+        sb.append(ValidatorParameters.VALIDATE_MODEL_NO_LOCAL_DEF);
+        sb.append(SEPARATOR);
+        sb.append("true");
+        sb.append(NEXT_LINE);
+        sb.append(PREFIX);
+        sb.append(ValidatorParameters.VALIDATE_NAMING);
+        sb.append(SEPARATOR);
+        sb.append("true");
+        sb.append(NEXT_LINE);
+        sb.append(PREFIX);
+        sb.append(ValidatorParameters.IGNORE_HEADER_X_NAMING);
+        sb.append(SEPARATOR);
+        sb.append("true");
+        sb.append(NEXT_LINE);
+        sb.append(PREFIX);
+        sb.append(ValidatorParameters.PATH_NAMING_CONVENTION);
+        sb.append(SEPARATOR_QUOTE);
+        sb.append(NamingConvention.HyphenCase);
+        sb.append(NEXT_LINE_QUOTE);
+        sb.append(PREFIX);
+        sb.append(ValidatorParameters.PARAMETER_NAMING_CONVENTION);
+        sb.append(SEPARATOR_QUOTE);
+        sb.append(NamingConvention.CamelCase);
+        sb.append(NEXT_LINE_QUOTE);
+        sb.append(PREFIX);
+        sb.append(ValidatorParameters.PROPERTY_NAMING_CONVENTION);
+        sb.append(SEPARATOR_QUOTE);
+        sb.append(NamingConvention.CamelCase);
+        sb.append("\"\n");
+        sb.append("}");
+        assertEquals(sb.toString(), content);
+    }
+
 }

--- a/gradle-plugin/src/main/java/org/openapitools/openapistylevalidator/gradle/OpenAPIStyleValidatorTask.java
+++ b/gradle-plugin/src/main/java/org/openapitools/openapistylevalidator/gradle/OpenAPIStyleValidatorTask.java
@@ -17,26 +17,6 @@ import java.util.List;
 
 public class OpenAPIStyleValidatorTask extends DefaultTask {
 
-    public static final String INPUT_FILE = "inputFile";
-
-    public static final String VALIDATE_INFO_LICENSE = "validateInfoLicense";
-    public static final String VALIDATE_INFO_DESCRIPTION = "validateInfoDescription";
-    public static final String VALIDATE_INFO_CONTACT = "validateInfoContact";
-
-    public static final String VALIDATE_OPERATION_OPERATION_ID = "validateOperationOperationId";
-    public static final String VALIDATE_OPERATION_DESCRIPTION = "validateOperationDescription";
-    public static final String VALIDATE_OPERATION_TAG = "validateOperationTag";
-    public static final String VALIDATE_OPERATION_SUMMARY = "validateOperationSummary";
-
-    public static final String VALIDATE_MODEL_PROPERTIES_EXAMPLE = "validateModelPropertiesExample";
-    public static final String VALIDATE_MODEL_NO_LOCAL_DEF = "validateModelNoLocalDef";
-
-    public static final String VALIDATE_NAMING = "validateNaming";
-    public static final String IGNORE_HEADER_X_NAMING = "ignoreHeaderXNaming";
-    public static final String PATH_NAMING_CONVENTION = "pathNamingConvention";
-    public static final String PARAMETER_NAMING_CONVENTION = "parameterNamingConvention";
-    public static final String PROPERTY_NAMING_CONVENTION = "propertyNamingConvention";
-
     private String inputFile;
 
     private boolean validateInfoLicense = true;
@@ -65,7 +45,7 @@ public class OpenAPIStyleValidatorTask extends DefaultTask {
     @TaskAction
     public void execute() {
         if (inputFile == null) {
-            throw new GradleException(String.format("The input file is not defined, set the '%s' option", INPUT_FILE));
+            throw new GradleException(String.format("The input file is not defined, set the '%s' option", OpenApiSpecStyleValidator.INPUT_FILE));
         }
         getLogger().quiet(String.format("Validating spec: %s", inputFile));
 
@@ -80,6 +60,7 @@ public class OpenAPIStyleValidatorTask extends DefaultTask {
         OpenApiSpecStyleValidator openApiSpecStyleValidator = new OpenApiSpecStyleValidator(openAPI);
 
         ValidatorParameters parameters = createValidatorParameters();
+        getLogger().quiet(String.format("Validating with options: %s", parameters));
         List<StyleError> result = openApiSpecStyleValidator.validate(parameters);
         if (!result.isEmpty()) {
             getLogger().error("OpenAPI Specification does not meet the requirements. Issues:\n");
@@ -88,77 +69,77 @@ public class OpenAPIStyleValidatorTask extends DefaultTask {
         }
     }
 
-    @Option(option = INPUT_FILE, description = "OpenAPI specification being validated")
+    @Option(option = OpenApiSpecStyleValidator.INPUT_FILE, description = "OpenAPI specification being validated")
     public void setInputFile(String inputFile) {
         this.inputFile = inputFile;
     }
 
-    @Option(option = VALIDATE_INFO_LICENSE, description = "Ensures that there is a license section in the info section")
+    @Option(option = ValidatorParameters.VALIDATE_INFO_LICENSE, description = "Ensures that there is a license section in the info section")
     public void setValidateInfoLicense(boolean validateInfoLicense) {
         this.validateInfoLicense = validateInfoLicense;
     }
 
-    @Option(option = VALIDATE_INFO_DESCRIPTION, description = "Ensures that there is a description attribute in the info section")
+    @Option(option = ValidatorParameters.VALIDATE_INFO_DESCRIPTION, description = "Ensures that there is a description attribute in the info section")
     public void setValidateInfoDescription(boolean validateInfoDescription) {
         this.validateInfoDescription = validateInfoDescription;
     }
 
-    @Option(option = VALIDATE_INFO_CONTACT, description = "Ensures that there is a contact section in the info section")
+    @Option(option = ValidatorParameters.VALIDATE_INFO_CONTACT, description = "Ensures that there is a contact section in the info section")
     public void setValidateInfoContact(boolean validateInfoContact) {
         this.validateInfoContact = validateInfoContact;
     }
 
-    @Option(option = VALIDATE_OPERATION_OPERATION_ID, description = "Ensures that there is an operation id for each operation")
+    @Option(option = ValidatorParameters.VALIDATE_OPERATION_OPERATION_ID, description = "Ensures that there is an operation id for each operation")
     public void setValidateOperationOperationId(boolean validateOperationOperationId) {
         this.validateOperationOperationId = validateOperationOperationId;
     }
 
-    @Option(option = VALIDATE_OPERATION_DESCRIPTION, description = "Ensures that there is a description for each operation")
+    @Option(option = ValidatorParameters.VALIDATE_OPERATION_DESCRIPTION, description = "Ensures that there is a description for each operation")
     public void setValidateOperationDescription(boolean validateOperationDescription) {
         this.validateOperationDescription = validateOperationDescription;
     }
 
-    @Option(option = VALIDATE_OPERATION_TAG, description = "Ensures that there is a tag for each operation")
+    @Option(option = ValidatorParameters.VALIDATE_OPERATION_TAG, description = "Ensures that there is a tag for each operation")
     public void setValidateOperationTag(boolean validateOperationTag) {
         this.validateOperationTag = validateOperationTag;
     }
 
-    @Option(option = VALIDATE_OPERATION_SUMMARY, description = "Ensures that there is a summary for each operation")
+    @Option(option = ValidatorParameters.VALIDATE_OPERATION_SUMMARY, description = "Ensures that there is a summary for each operation")
     public void setValidateOperationSummary(boolean validateOperationSummary) {
         this.validateOperationSummary = validateOperationSummary;
     }
 
-    @Option(option = VALIDATE_MODEL_PROPERTIES_EXAMPLE, description = "Ensures that the properties of the Schemas have an example value defined")
+    @Option(option = ValidatorParameters.VALIDATE_MODEL_PROPERTIES_EXAMPLE, description = "Ensures that the properties of the Schemas have an example value defined")
     public void setValidateModelPropertiesExample(boolean validateModelPropertiesExample) {
         this.validateModelPropertiesExample = validateModelPropertiesExample;
     }
 
-    @Option(option = VALIDATE_MODEL_NO_LOCAL_DEF, description = "Not implemented yet")
+    @Option(option = ValidatorParameters.VALIDATE_MODEL_NO_LOCAL_DEF, description = "Not implemented yet")
     public void setValidateModelNoLocalDef(boolean validateModelNoLocalDef) {
         this.validateModelNoLocalDef = validateModelNoLocalDef;
     }
 
-    @Option(option = VALIDATE_NAMING, description = "Ensures the names follow a given naming convention")
+    @Option(option = ValidatorParameters.VALIDATE_NAMING, description = "Ensures the names follow a given naming convention")
     public void setValidateNaming(boolean validateNaming) {
         this.validateNaming = validateNaming;
     }
 
-    @Option(option = IGNORE_HEADER_X_NAMING, description = "Exclude from validation header parameters starting with 'x-'")
+    @Option(option = ValidatorParameters.IGNORE_HEADER_X_NAMING, description = "Exclude from validation header parameters starting with 'x-'")
     public void setIgnoreHeaderXNaming(boolean ignoreHeaderXNaming) {
         this.ignoreHeaderXNaming = ignoreHeaderXNaming;
     }
 
-    @Option(option = PATH_NAMING_CONVENTION, description = "Naming convention for paths")
+    @Option(option = ValidatorParameters.PATH_NAMING_CONVENTION, description = "Naming convention for paths")
     public void setPathNamingConvention(NamingConvention pathNamingConvention) {
         this.pathNamingConvention = pathNamingConvention;
     }
 
-    @Option(option = PARAMETER_NAMING_CONVENTION, description = "Naming convention for parameters")
+    @Option(option = ValidatorParameters.PARAMETER_NAMING_CONVENTION, description = "Naming convention for parameters")
     public void setParameterNamingConvention(NamingConvention parameterNamingConvention) {
         this.parameterNamingConvention = parameterNamingConvention;
     }
 
-    @Option(option = PROPERTY_NAMING_CONVENTION, description = "Naming convention for properties")
+    @Option(option = ValidatorParameters.PROPERTY_NAMING_CONVENTION, description = "Naming convention for properties")
     public void setPropertyNamingConvention(NamingConvention propertyNamingConvention) {
         this.propertyNamingConvention = propertyNamingConvention;
     }

--- a/lib/src/main/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidator.java
+++ b/lib/src/main/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidator.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 
 public class OpenApiSpecStyleValidator {
+    public static final String INPUT_FILE = "inputFile";
 
     private final OpenAPI openAPI;
     private final ErrorAggregator errorAggregator;

--- a/lib/src/main/java/org/openapitools/openapistylevalidator/ValidatorParameters.java
+++ b/lib/src/main/java/org/openapitools/openapistylevalidator/ValidatorParameters.java
@@ -1,6 +1,23 @@
 package org.openapitools.openapistylevalidator;
 
 public class ValidatorParameters {
+    public static final String VALIDATE_INFO_LICENSE = "validateInfoLicense";
+    public static final String VALIDATE_INFO_DESCRIPTION = "validateInfoDescription";
+    public static final String VALIDATE_INFO_CONTACT = "validateInfoContact";
+
+    public static final String VALIDATE_OPERATION_OPERATION_ID = "validateOperationOperationId";
+    public static final String VALIDATE_OPERATION_DESCRIPTION = "validateOperationDescription";
+    public static final String VALIDATE_OPERATION_TAG = "validateOperationTag";
+    public static final String VALIDATE_OPERATION_SUMMARY = "validateOperationSummary";
+
+    public static final String VALIDATE_MODEL_PROPERTIES_EXAMPLE = "validateModelPropertiesExample";
+    public static final String VALIDATE_MODEL_NO_LOCAL_DEF = "validateModelNoLocalDef";
+
+    public static final String VALIDATE_NAMING = "validateNaming";
+    public static final String IGNORE_HEADER_X_NAMING = "ignoreHeaderXNaming";
+    public static final String PATH_NAMING_CONVENTION = "pathNamingConvention";
+    public static final String PARAMETER_NAMING_CONVENTION = "parameterNamingConvention";
+    public static final String PROPERTY_NAMING_CONVENTION = "propertyNamingConvention";
 
     public static enum NamingConvention {
         UnderscoreCase("underscore_case"),
@@ -227,5 +244,25 @@ public class ValidatorParameters {
     public ValidatorParameters setIgnoreHeaderXNaming(boolean ignoreHeaderXNaming) {
         this.ignoreHeaderXNaming = ignoreHeaderXNaming;
         return this;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "ValidatorParameters [validateInfoLicense=%s, validateInfoDescription=%s, validateInfoContact=%s, validateOperationOperationId=%s, validateOperationDescription=%s, validateOperationTag=%s, validateOperationSummary=%s, validateModelPropertiesExample=%s, validateModelNoLocalDef=%s, validateNaming=%s, ignoreHeaderXNaming=%s, pathNamingConvention=%s, parameterNamingConvention=%s, propertyNamingConvention=%s]",
+                validateInfoLicense, 
+                validateInfoDescription, 
+                validateInfoContact, 
+                validateOperationOperationId, 
+                validateOperationDescription,
+                validateOperationTag, 
+                validateOperationSummary,
+                validateModelPropertiesExample, 
+                validateModelNoLocalDef,
+                validateNaming, 
+                ignoreHeaderXNaming,
+                pathNamingConvention, 
+                parameterNamingConvention,
+                propertyNamingConvention);
     }
 }

--- a/maven-plugin/build.gradle
+++ b/maven-plugin/build.gradle
@@ -1,0 +1,61 @@
+plugins {
+    id 'de.benediktritter.maven-plugin-development' version '0.2.1'
+}
+
+dependencies {
+    implementation project(':lib')
+    implementation 'io.swagger.parser.v3:swagger-parser:2.0.20'
+    implementation 'org.openapitools.empoa:empoa-swagger-core:1.2.0'
+
+    compile 'org.apache.maven:maven-plugin-api:3.6.3'
+    compileOnly 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.0'
+}
+
+mavenPlugin {
+    artifactId = 'openapi-style-validator-maven-plugin'
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar) {
+    from javadoc
+    classifier = 'javadoc'
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = 'openapi-style-validator-maven-plugin'
+            pom {
+                name = 'OpenAPI Style Validator - maven-plugin'
+                description = 'Maven plugin to validate the style and standards of an OpenAPI specification'
+                url = 'https://openapitools.github.io/openapi-style-validator/'
+                inceptionYear = '2020'
+                licenses {
+                    license {
+                        name = 'Apache 2.0 License'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'JFCote'
+                        name = 'Jean-Francois Cote'
+                        email = 'jcote@stingray.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:https://github.com/openapitools/openapi-style-validator.git'
+                    developerConnection = 'scm:git:https://github.com/openapitools/openapi-style-validator.git'
+                    url = 'https://github.com/openapitools/openapi-style-validator/'
+                }
+            }
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+        }
+    }
+}

--- a/maven-plugin/src/main/java/org/openapitools/openapistylevalidator/maven/OpenAPIStyleValidatorMojo.java
+++ b/maven-plugin/src/main/java/org/openapitools/openapistylevalidator/maven/OpenAPIStyleValidatorMojo.java
@@ -1,0 +1,114 @@
+package org.openapitools.openapistylevalidator.maven;
+
+import java.util.List;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.openapitools.empoa.swagger.core.internal.SwAdapter;
+import org.openapitools.openapistylevalidator.OpenApiSpecStyleValidator;
+import org.openapitools.openapistylevalidator.ValidatorParameters;
+import org.openapitools.openapistylevalidator.ValidatorParameters.NamingConvention;
+import org.openapitools.openapistylevalidator.styleerror.StyleError;
+
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+
+@Mojo(name = "validate", defaultPhase = LifecyclePhase.VERIFY)
+public class OpenAPIStyleValidatorMojo extends AbstractMojo {
+
+    @Parameter(property = OpenApiSpecStyleValidator.INPUT_FILE)
+    private String inputFile;
+
+    @Parameter(property = ValidatorParameters.VALIDATE_INFO_LICENSE, defaultValue = "true")
+    private boolean validateInfoLicense = true;
+
+    @Parameter(property = ValidatorParameters.VALIDATE_INFO_DESCRIPTION, defaultValue = "true")
+    private boolean validateInfoDescription = true;
+
+    @Parameter(property = ValidatorParameters.VALIDATE_INFO_CONTACT, defaultValue = "true")
+    private boolean validateInfoContact = true;
+
+    @Parameter(property = ValidatorParameters.VALIDATE_OPERATION_OPERATION_ID, defaultValue = "true")
+    private boolean validateOperationOperationId = true;
+
+    @Parameter(property = ValidatorParameters.VALIDATE_OPERATION_DESCRIPTION, defaultValue = "true")
+    private boolean validateOperationDescription = true;
+
+    @Parameter(property = ValidatorParameters.VALIDATE_OPERATION_TAG, defaultValue = "true")
+    private boolean validateOperationTag = true;
+
+    @Parameter(property = ValidatorParameters.VALIDATE_OPERATION_SUMMARY, defaultValue = "true")
+    private boolean validateOperationSummary = true;
+
+    @Parameter(property = ValidatorParameters.VALIDATE_MODEL_PROPERTIES_EXAMPLE, defaultValue = "true")
+    private boolean validateModelPropertiesExample = true;
+
+    @Parameter(property = ValidatorParameters.VALIDATE_MODEL_NO_LOCAL_DEF, defaultValue = "true")
+    private boolean validateModelNoLocalDef = true;
+
+    @Parameter(property = ValidatorParameters.VALIDATE_NAMING, defaultValue = "true")
+    private boolean validateNaming = true;
+
+    @Parameter(property = ValidatorParameters.IGNORE_HEADER_X_NAMING, defaultValue = "true")
+    private boolean ignoreHeaderXNaming = true;
+
+    @Parameter(property = ValidatorParameters.PATH_NAMING_CONVENTION, defaultValue = "HyphenCase")
+    private NamingConvention pathNamingConvention = NamingConvention.HyphenCase;
+
+    @Parameter(property = ValidatorParameters.PARAMETER_NAMING_CONVENTION, defaultValue = "CamelCase")
+    private NamingConvention parameterNamingConvention = NamingConvention.CamelCase;
+
+    @Parameter(property = ValidatorParameters.PROPERTY_NAMING_CONVENTION, defaultValue = "CamelCase")
+    private NamingConvention propertyNamingConvention = NamingConvention.CamelCase;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (inputFile == null) {
+            throw new MojoExecutionException(String.format("The input file is not defined, set the '%s' option", OpenApiSpecStyleValidator.INPUT_FILE));
+        }
+        getLog().info(String.format("Validating spec: %s", inputFile));
+
+        OpenAPIParser openApiParser = new OpenAPIParser();
+        ParseOptions parseOptions = new ParseOptions();
+        parseOptions.setResolve(true);
+
+        SwaggerParseResult parserResult = openApiParser.readLocation(inputFile, null, parseOptions);
+        io.swagger.v3.oas.models.OpenAPI swaggerOpenAPI = parserResult.getOpenAPI();
+
+        org.eclipse.microprofile.openapi.models.OpenAPI openAPI = SwAdapter.toOpenAPI(swaggerOpenAPI);
+        OpenApiSpecStyleValidator openApiSpecStyleValidator = new OpenApiSpecStyleValidator(openAPI);
+
+        ValidatorParameters parameters = createValidatorParameters();
+        getLog().debug(String.format("Validating with options: %s", parameters));
+        List<StyleError> result = openApiSpecStyleValidator.validate(parameters);
+        if (!result.isEmpty()) {
+            getLog().error("OpenAPI Specification does not meet the requirements. Issues:\n");
+            result.stream().map(StyleError::toString).forEach(m -> getLog().error(String.format("\t%s", m)));
+            throw new MojoExecutionException("OpenAPI Style validation failed");
+        }
+    }
+
+    public ValidatorParameters createValidatorParameters() {
+        ValidatorParameters parameters = new ValidatorParameters();
+        parameters.setValidateInfoLicense(validateInfoLicense);
+        parameters.setValidateInfoDescription(validateInfoDescription);
+        parameters.setValidateInfoContact(validateInfoContact);
+        parameters.setValidateOperationOperationId(validateOperationOperationId);
+        parameters.setValidateOperationDescription(validateOperationDescription);
+        parameters.setValidateOperationTag(validateOperationTag);
+        parameters.setValidateOperationSummary(validateOperationSummary);
+        parameters.setValidateModelPropertiesExample(validateModelPropertiesExample);
+        parameters.setValidateModelNoLocalDef(validateModelNoLocalDef);
+        parameters.setValidateNaming(validateNaming);
+        parameters.setIgnoreHeaderXNaming(ignoreHeaderXNaming);
+        parameters.setPathNamingConvention(pathNamingConvention);
+        parameters.setParameterNamingConvention(parameterNamingConvention);
+        parameters.setPropertyNamingConvention(propertyNamingConvention);
+        return parameters;
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,3 +3,4 @@ rootProject.name = 'openapi-style-validator'
 include ":lib"
 include ":cli"
 include ":gradle-plugin"
+include ":maven-plugin"


### PR DESCRIPTION
Closes #20.

---

**Usage example:**

Run `./gradlew publishToMavenLocal` until we have published a release to Maven Central.

Example pom:

(Change the value of `____path-to____` in order to point to [petstore.yaml](https://github.com/OpenAPITools/openapi-style-validator/blob/master/specs/petstore.yaml) or use a different OpenAPI spec).

```xml
<project xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
  <modelVersion>4.0.0</modelVersion>
  <groupId>tmp</groupId>
  <artifactId>tmp</artifactId>
  <version>0.0.1-SNAPSHOT</version>
  <packaging>pom</packaging>

  <build>
    <plugins>
      <plugin>
        <groupId>org.openapitools.openapistylevalidator</groupId>
        <artifactId>openapi-style-validator-maven-plugin</artifactId>
        <version>1.4-SNAPSHOT</version>
        <executions>
          <execution>
            <phase>verify</phase>
            <goals>
              <goal>validate</goal>
            </goals>
          </execution>
        </executions>
        <configuration>
          <inputFile>/____path-to____/openapi-style-validator/specs/petstore.yaml</inputFile>
          <validateModelPropertiesExample>false</validateModelPropertiesExample>
          <pathNamingConvention>CamelCase</pathNamingConvention>
        </configuration>
      </plugin>
    </plugins>
  </build>
</project>
```

In the project of the `pom.xml` run `mvn verify`.
