### PR TITLE
Gradle improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ subprojects {
     apply plugin: 'de.marcphilipp.nexus-publish'
     apply plugin: 'jacoco'
 
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+
     test {
         useJUnitPlatform()
     }

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
     group = 'org.openapitools.openapistylevalidator'
 
     dependencies {
-        compile 'org.slf4j:slf4j-api:1.7.30'
+        implementation 'org.slf4j:slf4j-api:1.7.30'
         testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
         testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
     }

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'application'
 
 dependencies {
-	compile project(':lib')
-	compile 'commons-cli:commons-cli:1.4'
-    compile 'com.google.code.gson:gson:2.8.6'
-    compile 'org.slf4j:slf4j-jdk14:1.7.30'
+    implementation project(':lib')
+    implementation 'commons-cli:commons-cli:1.4'
+    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'org.slf4j:slf4j-jdk14:1.7.30'
 
-	compile 'io.swagger.parser.v3:swagger-parser:2.0.24'
-	compile 'org.openapitools.empoa:empoa-swagger-core:1.2.1'
+    implementation 'io.swagger.parser.v3:swagger-parser:2.0.24'
+    implementation 'org.openapitools.empoa:empoa-swagger-core:1.2.1'
 }
 
 mainClassName = 'org.openapitools.openapistylevalidator.cli.Main'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-    compile 'org.eclipse.microprofile.openapi:microprofile-openapi-api:2.0-MR1'
-    testCompile 'org.slf4j:slf4j-jdk14:1.7.30'
-    testCompile 'org.openapitools.empoa:empoa-simple-models-impl:1.2.1'
-    testCompile 'nl.jqno.equalsverifier:equalsverifier:3.5.1'
+    implementation 'org.eclipse.microprofile.openapi:microprofile-openapi-api:2.0-MR1'
+    testImplementation 'org.slf4j:slf4j-jdk14:1.7.30'
+    testImplementation 'org.openapitools.empoa:empoa-simple-models-impl:1.2.1'
+    testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.5.1'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/maven-plugin/build.gradle
+++ b/maven-plugin/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation 'io.swagger.parser.v3:swagger-parser:2.0.24'
     implementation 'org.openapitools.empoa:empoa-swagger-core:1.2.1'
 
-    compile 'org.apache.maven:maven-plugin-api:3.6.3'
+    implementation 'org.apache.maven:maven-plugin-api:3.6.3'
     compileOnly 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.0'
 }
 


### PR DESCRIPTION
Fix the warnings that can be seen with `--warning-mode all`:

```
The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the implementation configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/6.8/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations
        at build_cqs1je0j8mpn3krdri7ha1wzt$_run_closure3$_closure7.doCall(/Users/jbr/Git/openapi-style-validator/build.gradle:45)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```

And:
```
The testCompile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the testImplementation configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/6.8/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations
        at build_a8belt11ka6ry1zho5wvd4w35$_run_closure1.doCall(/Users/jbr/Git/openapi-style-validator/lib/build.gradle:3)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```

Set the source and target compatibility value to be able to test with Java 14 (see #104)