### PR TITLE
Fix model example validation error that occurs when there is an array…

### DIFF
--- a/lib/src/main/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidator.java
+++ b/lib/src/main/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidator.java
@@ -115,8 +115,9 @@ public class OpenApiSpecStyleValidator {
     private void validateModelProperties(String modelName, Schema model) {
         if (model.getProperties() != null) {
             model.getProperties().forEach((propertyName, property) -> {
-                if (parameters.isValidateModelPropertiesExample()
-                        && property.getRef() == null && property.getExample() == null) {
+                if (parameters.isValidateModelPropertiesExample() && property.getExample() == null
+                        && ((property.getItems() == null && property.getRef() == null)
+                            || (property.getItems() != null && property.getItems().getRef() == null))) {
                         errorAggregator.logMissingOrEmptyModelAttribute(modelName, propertyName, "example");
                 }
                 /*

--- a/lib/src/test/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidatorTest.java
+++ b/lib/src/test/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidatorTest.java
@@ -1,6 +1,7 @@
 package org.openapitools.openapistylevalidator;
 
 import java.util.List;
+
 import org.eclipse.microprofile.openapi.OASFactory;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.media.Schema.SchemaType;
@@ -61,6 +62,25 @@ class OpenApiSpecStyleValidatorTest {
         assertEquals(0, errors.size());
     }
 
+    //Test for bug 169
+    @Test
+    void testModelPropertiesExampleValidationIgnoresItemsRefProperty() {
+         OpenAPI openAPI = createValidOpenAPI()
+                .components(
+                        OASFactory.createComponents()
+                                .addSchema("MyObject", OASFactory.createSchema()
+                                        .addProperty("refProperty", OASFactory.createSchema()
+                                                .items( OASFactory.createSchema()
+                                                .ref("#/components/schemas/RefProperty"))))
+                );
+
+        ValidatorParameters parameters = TestDataProvider.createParametersDisablingAllValidations()
+                .setValidateModelPropertiesExample(true);
+
+        List<StyleError> errors = new OpenApiSpecStyleValidator(openAPI).validate(parameters);
+        assertEquals(0, errors.size());
+    }
+
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void validateModelRequiredProperties(boolean isValidateModelRequiredProperties) {
@@ -96,6 +116,7 @@ class OpenApiSpecStyleValidatorTest {
         List<StyleError> errors = validator.validate(new ValidatorParameters());
         assertEquals(0, errors.size());
     }
+
 
     private static OpenAPI createValidOpenAPI() {
         return OASFactory.createOpenAPI()


### PR DESCRIPTION
Fix model example validation error that occurs when there is an array property and a ref is used to generate the example.

For issue [169](https://github.com/OpenAPITools/openapi-style-validator/issues/169)