### PR TITLE
Test only JDK LTS versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,7 @@ script: ./gradlew build
 language: java
 jdk:
   - openjdk8
-  - openjdk9
-  - openjdk10
   - openjdk11
-  - openjdk12
 
 jobs:
   include:


### PR DESCRIPTION
Test only JDK LTS versions to reduce credits in Travis free plan for OSS as we're already running out of credits.

We may later test these non-LTM JDK versions in Github action (but Github action may one day impose similar credit limit on OSS builds)  