### PR TITLE
Error for wrong naming convention

### DIFF
--- a/cli/src/main/java/org/openapitools/openapistylevalidator/cli/OptionManager.java
+++ b/cli/src/main/java/org/openapitools/openapistylevalidator/cli/OptionManager.java
@@ -79,27 +79,42 @@ class OptionManager {
                 fixConventionRenaming(jsonElement, "property");
                 Gson gson = new GsonBuilder().create();
                 parameters = gson.fromJson(jsonElement, ValidatorParameters.class);
+                validateNamingConventions(parameters);
             } catch (java.io.IOException ignored) {
                 System.out.println("Invalid path to option files, using default.");
             } catch (com.google.gson.JsonSyntaxException e) {
                 System.out.println("Invalid JSON, using default.");;
             }
         }
+
         return parameters;
     }
 
     private void fixConventionRenaming(JsonElement jsonElement, String prefix) {
         JsonObject jsonObject = jsonElement.getAsJsonObject();
         String strategyKey = String.format("%sNamingStrategy", prefix);
-        if(jsonObject.has(strategyKey)) {
+        if (jsonObject.has(strategyKey)) {
             String conventionKey = String.format("%sNamingConvention", prefix);
-            if(jsonObject.has(conventionKey)) {
+            if (jsonObject.has(conventionKey)) {
                 System.err.println(String.format("The deprecated option '%s' is ignored, because its replacement '%s' is set", strategyKey, conventionKey));
             } else {
-                System.err.println(String.format("The option '%s' is depreacted, please use '%s' instead", strategyKey, conventionKey));
+                System.err.println(String.format("The option '%s' is deprecated, please use '%s' instead", strategyKey, conventionKey));
                 jsonObject.add(conventionKey, jsonObject.get(strategyKey));
             }
         }
+    }
+
+    private void validateNamingConventions(ValidatorParameters parameters) {
+        validateNamingConvention("header", parameters.getHeaderNamingConvention());
+        validateNamingConvention("parameter", parameters.getParameterNamingConvention());
+        validateNamingConvention("path", parameters.getPathNamingConvention());
+        validateNamingConvention("property", parameters.getPropertyNamingConvention());
+    }
+
+    private void validateNamingConvention(String kind, ValidatorParameters.NamingConvention convention) {
+        if (convention != null) return;
+        throw new IllegalArgumentException(
+                "Invalid " + (kind.toLowerCase()) + "NamingConvention");
     }
 
     String getSource(CommandLine commandLine) {

--- a/cli/src/test/java/org/openapitools/openapistylevalidator/cli/MainTest.java
+++ b/cli/src/test/java/org/openapitools/openapistylevalidator/cli/MainTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -235,6 +236,66 @@ public class MainTest {
         sb.append(System.lineSeparator());
         sb.append("}");
         assertEquals(sb.toString(), content);
+    }
+
+    @Test
+    void validateShouldThrowIllegalArgumentExceptionForInvalidPathNamingConvention() throws ParseException {
+        OptionManager optionManager = new OptionManager();
+        Options options = optionManager.getOptions();
+        CommandLine commandLine = parser.parse(options, new String[]{
+                "-s", "src/test/resources/some.yaml",
+                "-o", "src/test/resources/invalidPathNamingConvention.json"
+        });
+
+        IllegalArgumentException thrown = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            Main.validate(optionManager, commandLine);
+        });
+        Assertions.assertEquals("Invalid pathNamingConvention", thrown.getMessage());
+    }
+
+    @Test
+    void validateShouldThrowIllegalArgumentExceptionForInvalidParameterNamingConvention() throws ParseException {
+        OptionManager optionManager = new OptionManager();
+        Options options = optionManager.getOptions();
+        CommandLine commandLine = parser.parse(options, new String[]{
+                "-s", "src/test/resources/some.yaml",
+                "-o", "src/test/resources/invalidParameterNamingConvention.json"
+        });
+
+        IllegalArgumentException thrown = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            Main.validate(optionManager, commandLine);
+        });
+        Assertions.assertEquals("Invalid parameterNamingConvention", thrown.getMessage());
+    }
+
+    @Test
+    void validateShouldThrowIllegalArgumentExceptionForInvalidHeaderNamingConvention() throws ParseException {
+        OptionManager optionManager = new OptionManager();
+        Options options = optionManager.getOptions();
+        CommandLine commandLine = parser.parse(options, new String[]{
+                "-s", "src/test/resources/some.yaml",
+                "-o", "src/test/resources/invalidHeaderNamingConvention.json"
+        });
+
+        IllegalArgumentException thrown = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            Main.validate(optionManager, commandLine);
+        });
+        Assertions.assertEquals("Invalid headerNamingConvention", thrown.getMessage());
+    }
+
+    @Test
+    void validateShouldThrowIllegalArgumentExceptionForInvalidPropertyNamingConvention() throws ParseException {
+        OptionManager optionManager = new OptionManager();
+        Options options = optionManager.getOptions();
+        CommandLine commandLine = parser.parse(options, new String[]{
+                "-s", "src/test/resources/some.yaml",
+                "-o", "src/test/resources/invalidPropertyNamingConvention.json"
+        });
+
+        IllegalArgumentException thrown = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            Main.validate(optionManager, commandLine);
+        });
+        Assertions.assertEquals("Invalid propertyNamingConvention", thrown.getMessage());
     }
 
 }

--- a/cli/src/test/resources/invalidHeaderNamingConvention.json
+++ b/cli/src/test/resources/invalidHeaderNamingConvention.json
@@ -1,0 +1,3 @@
+{
+  "headerNamingConvention": "Wrong naming convention"
+}

--- a/cli/src/test/resources/invalidParameterNamingConvention.json
+++ b/cli/src/test/resources/invalidParameterNamingConvention.json
@@ -1,0 +1,3 @@
+{
+  "parameterNamingConvention": "Wrong naming convention"
+}

--- a/cli/src/test/resources/invalidPathNamingConvention.json
+++ b/cli/src/test/resources/invalidPathNamingConvention.json
@@ -1,0 +1,3 @@
+{
+  "pathNamingConvention": "Wrong naming convention"
+}

--- a/cli/src/test/resources/invalidPropertyNamingConvention.json
+++ b/cli/src/test/resources/invalidPropertyNamingConvention.json
@@ -1,0 +1,3 @@
+{
+  "propertyNamingConvention": "Wrong naming convention"
+}


### PR DESCRIPTION
The cli will now validate the naming conventions and report them through an IllegalArgumentException with a detailed message instead of a NullPointerException.

Relates to https://github.com/OpenAPITools/openapi-style-validator/issues/148

This commit will also fix a typo in `fixConventionRenaming`: "depre[a]cated"