### PR TITLE
Fix #245: Add cache to make the build faster

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    #strategy:
-    #  matrix:
-    #    java: [ '8', '11', '16' ]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -20,7 +17,8 @@ jobs:
         uses: actions/setup-java@v2.3.1
         with:
           distribution: 'adopt'
-          java-version: 11 #${{ matrix.java }}
+          java-version: 11
+          cache: 'gradle'
       - name: print Java version
         run: java -version
       - name: Cache SonarCloud packages


### PR DESCRIPTION
Dependabot updated to a new version but didn't add the new parameter to turn on the caching.