### PR TITLE
Use new notation to configure sources and javadoc jars

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -43,14 +43,9 @@ shadowJar {
 
 project.tasks.assemble.dependsOn project.tasks.shadowJar
 
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar) {
-    from javadoc
-    classifier = 'javadoc'
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
 publishing {
@@ -83,8 +78,6 @@ publishing {
                 }
             }
             from components.java
-            artifact sourcesJar
-            artifact javadocJar
         }
     }
 }

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -18,14 +18,9 @@ gradlePlugin {
     }
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar) {
-    from javadoc
-    classifier = 'javadoc'
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
 // Add a source set for the functional test suite
@@ -80,8 +75,6 @@ publishing {
             pluginMaven {
                 artifactId = 'openapi-style-validator-gradle-plugin'
                 // customize main publications here
-                artifact sourcesJar
-                artifact javadocJar
                 pom {
                     name = 'OpenAPI Style Validator - gradle plugin'
                     description = 'Gradle plugin to validate the style and standards of an OpenAPI specification'

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -5,14 +5,9 @@ dependencies {
     testImplementation 'nl.jqno.equalsverifier:equalsverifier:3.9'
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar) {
-    from javadoc
-    classifier = 'javadoc'
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
 publishing {
@@ -45,8 +40,6 @@ publishing {
                 }
             }
             from components.java
-            artifact sourcesJar
-            artifact javadocJar
         }
     }
 }

--- a/maven-plugin/build.gradle
+++ b/maven-plugin/build.gradle
@@ -15,14 +15,9 @@ mavenPlugin {
     artifactId = 'openapi-style-validator-maven-plugin'
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar) {
-    from javadoc
-    classifier = 'javadoc'
+java {
+    withJavadocJar()
+    withSourcesJar()
 }
 
 publishing {
@@ -54,8 +49,6 @@ publishing {
                 }
             }
             from components.java
-            artifact sourcesJar
-            artifact javadocJar
         }
     }
 }


### PR DESCRIPTION
Simplify `build.gradle` using new feature.