### PR TITLE
Add integration tests for the maven plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /out/
 bin
 build
+target
 
 /website/node_modules
 /cli/build

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,9 @@ subprojects {
     targetCompatibility = 1.8
 
     test {
-        useJUnitPlatform()
+        if(project.name != 'openapi-style-validator-maven-plugin') {
+            useJUnitPlatform()
+        }
     }
 
     repositories {

--- a/maven-plugin/build.gradle
+++ b/maven-plugin/build.gradle
@@ -2,13 +2,30 @@ plugins {
     id 'de.benediktritter.maven-plugin-development' version '0.4.0'
 }
 
+configurations {
+    takariWorkspace
+}
+
 dependencies {
+    takariWorkspace('io.takari.m2e.workspace:org.eclipse.m2e.workspace.cli:0.4.0') {
+        exclude group: 'javax.inject', module: 'javax.inject'
+        exclude group: 'org.codehaus.plexus', module: 'plexus-component-annotations'
+    }
+
     implementation project(':openapi-style-validator-lib')
     implementation 'io.swagger.parser.v3:swagger-parser:2.0.31'
     implementation 'org.openapitools.empoa:empoa-swagger-core:2.0.0'
 
     implementation 'org.apache.maven:maven-plugin-api:3.8.5'
     compileOnly 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.4'
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.hamcrest:hamcrest-core:1.3'
+    testImplementation 'io.takari.maven.plugins:takari-plugin-testing:3.0.0'
+    testImplementation 'io.takari.maven.plugins:takari-plugin-integration-testing:3.0.0'
+    testImplementation 'org.assertj:assertj-core:3.6.2'
+    testRuntimeOnly 'org.apache.maven:maven-compat:3.6.3'
+    testRuntimeOnly 'org.apache.maven:maven-core:3.6.3'
 }
 
 mavenPlugin {
@@ -52,3 +69,63 @@ publishing {
         }
     }
 }
+
+// Add the mojo descriptor to the test source-set (workaround https://github.com/britter/maven-plugin-development/issues/76)
+sourceSets.test.output.dir file("$buildDir/mavenPlugin/descriptor"), builtBy: generateMavenPluginDescriptor
+
+def genOutputDir = file("$buildDir/generated/test-resources")
+
+task generateTakariTestResources {
+    dependsOn getRootProject().getTasksByName("jar", true)
+    dependsOn getRootProject().getTasksByName("generatePomFileForMavenJavaPublication", true)
+
+    def testProperties = new File(genOutputDir, "test.properties")
+    outputs.file(testProperties)
+
+    def workspaceStateProperties = file("$buildDir/maven-work/workspacestate.properties")
+    outputs.file(workspaceStateProperties)
+
+    doLast {
+        // Generate 'workspacestate.properties' file
+        java.util.Properties workspaceProp = new java.util.Properties();
+        getRootProject().getAllprojects().each { prj -> 
+            def ext = prj.getExtensions().findByType(PublishingExtension.class);
+            if(ext != null) {
+                ext.getPublications().each { pub -> 
+                    addProject(workspaceProp, prj)
+                }
+            }
+        }
+        workspaceProp.store(new java.io.FileOutputStream(workspaceStateProperties), "workspace state file")
+
+        // Generate 'test.properties' file
+        // See https://github.com/takari/takari-plugin-testing-project/blob/master/testproperties.md
+        java.util.Properties testProp = new java.util.Properties();
+
+        testProp.setProperty("project.groupId", getProject().getGroup().toString());
+        testProp.setProperty("project.artifactId", getProject().getConvention().getPlugin(BasePluginConvention.class).getArchivesBaseName());
+        testProp.setProperty("project.version", getProject().getVersion().toString());
+
+        testProp.setProperty("classpath", "" + jar.archiveFile.get().asFile + ":" + configurations.runtimeClasspath.getAsPath());
+
+        testProp.setProperty("localRepository", System.getProperty("user.home") + "/.m2/repository");
+        testProp.setProperty("repository.0", "<id>central</id><url>https://repo.maven.apache.org/maven2</url><releases><enabled>true</enabled></releases><snapshots><enabled>false</enabled></snapshots>");
+        testProp.setProperty("updateSnapshots", "false");
+        // testProp.setProperty("globalSettingsFile", null);
+        File userSettingsFile = new File(System.getProperty("user.home") + "/.m2/settings.xml")
+        if(userSettingsFile.exists()) {
+            testProp.setProperty("userSettingsFile", userSettingsFile.getAbsolutePath());
+        }
+        testProp.setProperty("workspaceResolver", project.configurations.takariWorkspace.asPath);
+        testProp.setProperty("workspaceStateProperties", workspaceStateProperties.getAbsolutePath());
+
+        testProp.store(new java.io.FileOutputStream(testProperties), "See https://github.com/takari/takari-plugin-testing-project/blob/master/testproperties.md")
+    }
+}
+
+def void addProject(java.util.Properties workspaceProp, Project p) {
+    workspaceProp.setProperty(p.getGroup().toString() + ":" + p.getConvention().getPlugin(BasePluginConvention.class).getArchivesBaseName() + ":jar::" + p.getVersion().toString(), new File(p.getBuildDir(), "/libs/${p.getConvention().getPlugin(BasePluginConvention.class).getArchivesBaseName()}-${p.getVersion().toString()}.jar").getAbsolutePath()); // jar.archiveFile.get().asFile.getAbsolutePath() ??
+    workspaceProp.setProperty(p.getGroup().toString() + ":" + p.getConvention().getPlugin(BasePluginConvention.class).getArchivesBaseName() + ":pom::" + p.getVersion().toString(), new File(p.getBuildDir(), "/publications/mavenJava/pom-default.xml").getAbsolutePath());
+}
+
+sourceSets.test.output.dir genOutputDir, builtBy: generateTakariTestResources

--- a/maven-plugin/build.gradle
+++ b/maven-plugin/build.gradle
@@ -123,7 +123,7 @@ task generateTakariTestResources {
 }
 
 def void addProject(java.util.Properties workspaceProp, Project p) {
-    workspaceProp.setProperty(p.getGroup().toString() + ":" + p.getConvention().getPlugin(BasePluginConvention.class).getArchivesBaseName() + ":jar::" + p.getVersion().toString(), new File(p.getBuildDir(), "/libs/${p.getConvention().getPlugin(BasePluginConvention.class).getArchivesBaseName()}-${p.getVersion().toString()}.jar").getAbsolutePath()); // jar.archiveFile.get().asFile.getAbsolutePath() ??
+    workspaceProp.setProperty(p.getGroup().toString() + ":" + p.getConvention().getPlugin(BasePluginConvention.class).getArchivesBaseName() + ":jar::" + p.getVersion().toString(), new File(p.getBuildDir(), "/libs/${p.getConvention().getPlugin(BasePluginConvention.class).getArchivesBaseName()}-${p.getVersion().toString()}.jar").getAbsolutePath());
     workspaceProp.setProperty(p.getGroup().toString() + ":" + p.getConvention().getPlugin(BasePluginConvention.class).getArchivesBaseName() + ":pom::" + p.getVersion().toString(), new File(p.getBuildDir(), "/publications/mavenJava/pom-default.xml").getAbsolutePath());
 }
 

--- a/maven-plugin/build.gradle
+++ b/maven-plugin/build.gradle
@@ -111,7 +111,6 @@ task generateTakariTestResources {
         testProp.setProperty("localRepository", System.getProperty("user.home") + "/.m2/repository");
         testProp.setProperty("repository.0", "<id>central</id><url>https://repo.maven.apache.org/maven2</url><releases><enabled>true</enabled></releases><snapshots><enabled>false</enabled></snapshots>");
         testProp.setProperty("updateSnapshots", "false");
-        // testProp.setProperty("globalSettingsFile", null);
         File userSettingsFile = new File(System.getProperty("user.home") + "/.m2/settings.xml")
         if (userSettingsFile.exists()) {
             testProp.setProperty("userSettingsFile", userSettingsFile.getAbsolutePath());

--- a/maven-plugin/build.gradle
+++ b/maven-plugin/build.gradle
@@ -113,7 +113,7 @@ task generateTakariTestResources {
         testProp.setProperty("updateSnapshots", "false");
         // testProp.setProperty("globalSettingsFile", null);
         File userSettingsFile = new File(System.getProperty("user.home") + "/.m2/settings.xml")
-        if(userSettingsFile.exists()) {
+        if (userSettingsFile.exists()) {
             testProp.setProperty("userSettingsFile", userSettingsFile.getAbsolutePath());
         }
         testProp.setProperty("workspaceResolver", project.configurations.takariWorkspace.asPath);

--- a/maven-plugin/src/test/java/org/openapitools/openapistylevalidator/maven/IntegrationTest.java
+++ b/maven-plugin/src/test/java/org/openapitools/openapistylevalidator/maven/IntegrationTest.java
@@ -1,0 +1,104 @@
+package org.openapitools.openapistylevalidator.maven;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.runner.RunWith;
+
+import io.takari.maven.testing.TestResources;
+import io.takari.maven.testing.executor.MavenExecutionResult;
+import io.takari.maven.testing.executor.MavenRuntime;
+import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
+import io.takari.maven.testing.executor.MavenVersions;
+import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+
+@RunWith(MavenJUnitTestRunner.class)
+@MavenVersions({"3.6.3"})
+public class IntegrationTest {
+
+  @Rule
+  public final TestResources resources = new TestResources("src/test/resources/projects", "build/maven-work");
+
+  private final MavenRuntime maven;
+
+  public IntegrationTest(MavenRuntimeBuilder builder) throws Exception {
+    this.maven = builder.build();
+  }
+
+  @Test
+  public void withEmptyPomShouldDisplaySixErrors() throws Exception {
+    Path file = Paths.get("../cli/src/test/resources/ping.yaml");
+    Assertions.assertTrue(Files.isRegularFile(file));
+
+    File basedir = resources.getBasedir("testEmpty");
+    MavenExecutionResult result = maven.forProject(basedir)
+        .execute("verify", "-X", "-Dit.inputFile=" + file.normalize().toAbsolutePath());
+
+    sixErrorsAssertions(result);
+  }
+
+  @Test
+  public void withDefaultPomShouldDisplaySixErrors() throws Exception {
+    Path file = Paths.get("../cli/src/test/resources/ping.yaml");
+    Assertions.assertTrue(Files.isRegularFile(file));
+
+    File basedir = resources.getBasedir("testDefault");
+    MavenExecutionResult result = maven.forProject(basedir)
+        .execute("verify", "-X", "-Dit.inputFile=" + file.normalize().toAbsolutePath());
+
+    sixErrorsAssertions(result);
+  }
+
+  private void sixErrorsAssertions(MavenExecutionResult result) {
+    result
+        .assertLogText("Validating spec:")
+        .assertLogText("cli/src/test/resources/ping.yaml")
+        .assertLogText("OpenAPI Specification does not meet the requirements. Issues:")
+        .assertLogText("*ERROR* Section: APIInfo: 'license' -> Should be present and not empty")
+        .assertLogText("*ERROR* Section: APIInfo: 'description' -> Should be present and not empty")
+        .assertLogText("*ERROR* Section: APIInfo: 'contact' -> Should be present and not empty")
+        .assertLogText("*ERROR* in Operation POST /ping 'description' -> This field should be present and not empty")
+        .assertLogText("*ERROR* in Operation POST /ping 'summary' -> This field should be present and not empty")
+        .assertLogText("*ERROR* in Operation POST /ping 'tags' -> The collection should be present and there should be at least one item in it")
+        .assertLogText("BUILD FAILURE");
+  }
+
+  @Test
+  public void withCustomPomShouldDisplaySixErrors() throws Exception {
+    Path file = Paths.get("../cli/src/test/resources/ping.yaml");
+    Assertions.assertTrue(Files.isRegularFile(file));
+
+    File basedir = resources.getBasedir("testCustom");
+    MavenExecutionResult result = maven.forProject(basedir)
+        .execute("verify", "-X", "-Dit.inputFile=" + file.normalize().toAbsolutePath());
+
+    result
+        .assertLogText("Validating spec:")
+        .assertLogText("cli/src/test/resources/ping.yaml")
+        .assertLogText("BUILD SUCCESS");
+  }
+
+  @Test
+  public void withEmptyPomShouldDisplayNamingErrors() throws Exception {
+    Path file = Paths.get("../cli/src/test/resources/some.yaml");
+    Assertions.assertTrue(Files.isRegularFile(file));
+
+    File basedir = resources.getBasedir("testCustom");
+    MavenExecutionResult result = maven.forProject(basedir)
+        .execute("verify", "-X", "-Dit.inputFile=" + file.normalize().toAbsolutePath());
+
+    result
+        .assertLogText("Validating spec:")
+        .assertLogText("cli/src/test/resources/some.yaml")
+        .assertLogText("OpenAPI Specification does not meet the requirements. Issues:")
+        .assertLogText("*ERROR* in path POST /some_path/{some_id} 'some_id' -> parameter should be in camelCase")
+        .assertLogText("*ERROR* in path POST /some_path/{some_id} 'some_name' -> parameter should be in camelCase")
+        .assertLogText("*ERROR* in path /some_path/{some_id} 'some_path' -> path should be in hyphen-case")
+        .assertLogText("BUILD FAILURE");
+  }
+}

--- a/maven-plugin/src/test/resources/projects/testCustom/pom.xml
+++ b/maven-plugin/src/test/resources/projects/testCustom/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>tmp</groupId>
+  <artifactId>project</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openapitools.openapistylevalidator</groupId>
+        <artifactId>openapi-style-validator-maven-plugin</artifactId>
+        <version>${it-plugin.version}</version>
+        <configuration>
+          <inputFile>${it.inputFile}</inputFile>
+          <validateInfoLicense>false</validateInfoLicense>
+          <validateInfoDescription>false</validateInfoDescription>
+          <validateInfoContact>false</validateInfoContact>
+          <validateOperationDescription>false</validateOperationDescription>
+          <validateOperationSummary>false</validateOperationSummary>
+          <validateOperationTag>false</validateOperationTag>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-plugin/src/test/resources/projects/testDefault/pom.xml
+++ b/maven-plugin/src/test/resources/projects/testDefault/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>tmp</groupId>
+  <artifactId>project</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openapitools.openapistylevalidator</groupId>
+        <artifactId>openapi-style-validator-maven-plugin</artifactId>
+        <version>${it-plugin.version}</version>
+        <configuration>
+          <inputFile>${it.inputFile}</inputFile>
+          <validateInfoLicense>true</validateInfoLicense>
+          <validateInfoDescription>true</validateInfoDescription>
+          <validateInfoContact>true</validateInfoContact>
+          <validateOperationOperationId>true</validateOperationOperationId>
+          <validateOperationDescription>true</validateOperationDescription>
+          <validateOperationTag>true</validateOperationTag>
+          <validateOperationSummary>true</validateOperationSummary>
+          <validateModelPropertiesExample>true</validateModelPropertiesExample>
+          <validateModelPropertiesDescription>true</validateModelPropertiesDescription>
+          <validateModelRequiredProperties>true</validateModelRequiredProperties>
+          <validateModelNoLocalDef>true</validateModelNoLocalDef>
+          <validateNaming>true</validateNaming>
+          <ignoreHeaderXNaming>true</ignoreHeaderXNaming>
+          <pathNamingConvention>HyphenCase</pathNamingConvention>
+          <headerNamingConvention>UnderscoreUpperCase</headerNamingConvention>
+          <parameterNamingConvention>CamelCase</parameterNamingConvention>
+          <propertyNamingConvention>CamelCase</propertyNamingConvention>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven-plugin/src/test/resources/projects/testEmpty/pom.xml
+++ b/maven-plugin/src/test/resources/projects/testEmpty/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>tmp</groupId>
+  <artifactId>project</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.openapitools.openapistylevalidator</groupId>
+        <artifactId>openapi-style-validator-maven-plugin</artifactId>
+        <version>${it-plugin.version}</version>
+        <configuration>
+          <inputFile>${it.inputFile}</inputFile>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
This PR adds functional tests for the maven plugin, following the approach discussed in https://github.com/britter/maven-plugin-development/issues/41#issuecomment-1063693407

The main change of this PR is the addition of the class: `IntegrationTest` containing some tests.

* Those tests are based on the POM files inside of `maven-plugin/src/test/resources/projects/`
    - `testEmpty/pom.xml`: only `inputFile` is configured inside the `<configuration>` bloc.
    - `testDefault/pom.xml`: configure all the properties inside `<configuration>` bloc with the default value.
    - `testEmpty/pom.xml`: configure some properties inside `<configuration>` with some custom values.
* In all test poms, the `inputFile` value is set to `${it.inputFile}`, the test will pass a value to the `it.inputFile` parameter.
* The tests are running maven with some parameters and they test if the build is successful or has found the expected error.

Those integration tests are really similar to the one defined in the `MainTest` of the cli project (same input file, same config, same expected errors).
