### PR TITLE
Rollback of swagger parser to previous minor because it breaks unit test

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation project(':openapi-style-validator-lib')
-    implementation 'io.swagger.parser.v3:swagger-parser:2.1.1'
+    implementation 'io.swagger.parser.v3:swagger-parser:2.0.33'
     implementation 'org.openapitools.empoa:empoa-swagger-core:2.0.0'
     testImplementation 'junit:junit:4.13.2'
 }

--- a/maven-plugin/build.gradle
+++ b/maven-plugin/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     }
 
     implementation project(':openapi-style-validator-lib')
-    implementation 'io.swagger.parser.v3:swagger-parser:2.1.1'
+    implementation 'io.swagger.parser.v3:swagger-parser:2.0.33'
     implementation 'org.openapitools.empoa:empoa-swagger-core:2.0.0'
 
     implementation 'org.apache.maven:maven-plugin-api:3.8.6'


### PR DESCRIPTION
For plugins. Keep the latest version for the CLI only.