### PR TITLE
Implemented new param naming convention options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ description, etc...
 - All required properties must be listed among the properties
 
 ### Naming convention
-- Enforce naming convention for paths, parameters, headers and properties
+- Enforce naming convention for paths, parameters (path, query and cookie), headers and properties
   - underscore_case
   - UNDERSCORE_UPPER_CASE
   - camelCase
@@ -91,25 +91,71 @@ Example using the default output path for the jar (replace `<version>` with the 
 #### Options File
 The options file is described in json (example in `specs/options.json`), and has the following possible values:
 
-|Option|Type|Possible Values|Description|
-|---|---|---|---|
-|validateInfoLicense|boolean|`true`, `false`|Ensures that there is a license section in the info section|
-|validateInfoDescription|boolean|`true`, `false`|Ensures that there is a description attribute in the info section|
-|validateInfoContact|boolean|`true`, `false`|Ensures that there is a contact section in the info section|
-|validateOperationOperationId|boolean|`true`, `false`|Ensures that there is an operation id for each operation|
-|validateOperationDescription|boolean|`true`, `false`|Ensures that there is a description for each operation|
-|validateOperationTag|boolean|`true`, `false`|Ensures that there is a tag for each operation|
-|validateOperationSummary|boolean|`true`, `false`|Ensures that there is a summary for each operation|
-|validateModelPropertiesExample|boolean|`true`, `false`|Ensures that the properties of the Schemas have an example value defined|
-|validateModelPropertiesDescription|boolean|`true`, `false`|Ensures that the properties of the Schemas have a description value defined|
-|validateModelRequiredProperties|boolean|`true`, `false`|Ensures that all required properties of the Schemas are listed among their properties|
-|validateModelNoLocalDef|boolean|`true`, `false`|Not implemented yet|
-|validateNaming|boolean|`true`, `false`|Ensures the names follow a given naming convention|
-|ignoreHeaderXNaming|boolean|`true`, `false`|Exclude from validation header parameters starting with `x-`|
-|pathNamingConvention|string|`CamelCase`, `HyphenUpperCase`, `HyphenCase`, `UnderscoreCase`, `UnderscoreUpperCase`, `AnyCase`|Naming convention for paths|
-|parameterNamingConvention|string|`CamelCase`, `HyphenUpperCase`, `HyphenCase`, `UnderscoreCase`, `UnderscoreUpperCase`, `AnyCase`|Naming convention for parameters|
-|headerNamingConvention|string|`CamelCase`, `HyphenUpperCase`, `HyphenCase`, `UnderscoreCase`, `UnderscoreUpperCase`, `AnyCase`|Naming convention for headers|
-|propertyNamingConvention|string|`CamelCase`, `HyphenUpperCase`, `HyphenCase`, `UnderscoreCase`, `UnderscoreUpperCase`, `AnyCase`|Naming convention for properties|
+|Option|Type|Possible Values|Default Value|Description|
+|---|---|---|---|---|
+|validateInfoLicense|boolean|`true`, `false`|`true`|Ensures that there is a license section in the info section|
+|validateInfoDescription|boolean|`true`, `false`|`true`|Ensures that there is a description attribute in the info section|
+|validateInfoContact|boolean|`true`, `false`|`true`|Ensures that there is a contact section in the info section|
+|validateOperationOperationId|boolean|`true`, `false`|`true`|Ensures that there is an operation id for each operation|
+|validateOperationDescription|boolean|`true`, `false`|`true`|Ensures that there is a description for each operation|
+|validateOperationTag|boolean|`true`, `false`|`true`|Ensures that there is a tag for each operation|
+|validateOperationSummary|boolean|`true`, `false`|`true`|Ensures that there is a summary for each operation|
+|validateModelPropertiesExample|boolean|`true`, `false`|`true`|Ensures that the properties of the Schemas have an example value defined|
+|validateModelPropertiesDescription|boolean|`true`, `false`|`true`|Ensures that the properties of the Schemas have a description value defined|
+|validateModelRequiredProperties|boolean|`true`, `false`|`true`|Ensures that all required properties of the Schemas are listed among their properties|
+|validateModelNoLocalDef|boolean|`true`, `false`|`true`|Not implemented yet|
+|validateNaming|boolean|`true`, `false`|`true`|Ensures the names follow a given naming convention|
+|ignoreHeaderXNaming|boolean|`true`, `false`|`true`|Exclude from validation header parameters starting with `x-`|
+|pathNamingConvention|string|`CamelCase`, `HyphenUpperCase`, `HyphenCase`, `UnderscoreCase`, `UnderscoreUpperCase`, `AnyCase`|`HyphenCase`|Naming convention for paths|
+|parameterNamingConvention|string|`CamelCase`, `HyphenUpperCase`, `HyphenCase`, `UnderscoreCase`, `UnderscoreUpperCase`, `AnyCase`|`CamelCase`|Global naming convention for all parameter types (path, query and cookie) [(note)](#parameter-naming-convention-hierarchy)|
+|pathParamNamingConvention|string|`CamelCase`, `HyphenUpperCase`, `HyphenCase`, `UnderscoreCase`, `UnderscoreUpperCase`, `AnyCase`|(same as `parameterNamingConvention`)|Specific naming convention for path parameters [(note)](#parameter-naming-convention-hierarchy)|
+|queryParamNamingConvention|string|`CamelCase`, `HyphenUpperCase`, `HyphenCase`, `UnderscoreCase`, `UnderscoreUpperCase`, `AnyCase`|(same as `parameterNamingConvention`)|Specific naming convention for query parameters [(note)](#parameter-naming-convention-hierarchy)|
+|cookieParamNamingConvention|string|`CamelCase`, `HyphenUpperCase`, `HyphenCase`, `UnderscoreCase`, `UnderscoreUpperCase`, `AnyCase`|(same as `parameterNamingConvention`)|Specific naming convention for cookie parameters [(note)](#parameter-naming-convention-hierarchy)|
+|headerNamingConvention|string|`CamelCase`, `HyphenUpperCase`, `HyphenCase`, `UnderscoreCase`, `UnderscoreUpperCase`, `AnyCase`|`UnderscoreUpperCase`|Naming convention for headers|
+|propertyNamingConvention|string|`CamelCase`, `HyphenUpperCase`, `HyphenCase`, `UnderscoreCase`, `UnderscoreUpperCase`, `AnyCase`|`CamelCase`|Naming convention for properties|
+
+#### Parameter Naming Convention hierarchy
+
+The Parameter Naming Convention can be defined by a combination of the following options in the `options.json` file:
+- parameterNamingConvention
+- pathParamNamingConvention
+- queryParamNamingConvention
+- cookieParamNamingConvention
+
+The first option (parameterNamingConvention) defines a global convention for all other parameter naming convention options (path, query and cookie), unless they are explicitly defined in the `options.json` file.
+
+In other words, the `pathParamNamingConvention`, `queryParamNamingConvention` and `cookieParamNamingConvention` are specific for the parameter type their names indicate. Thus, they take precedence over `parameterNamingConvention` when they are defined. If not defined, the undefined option is assigned the same value for `parameterNamingConvention` (either explicitly defined or default).
+
+Example 1:
+```json
+{
+  /*
+    'parameterNamingConvention' is not defined.
+        Then it assumes the 'CamelCase' convention.
+   */
+  "pathParamNamingConvention": "UnderscoreCase",
+  "queryParamNamingConvention": "HyphenCase"
+  /*
+    'cookieParamNamingConvention' is not defined.
+        Then it assumes the same value as 'parameterNamingConvention',
+        which is its default value ('CamelCase').
+   */
+}
+```
+
+Example 2:
+```json
+{
+  "parameterNamingConvention": "HyphenCase",
+  "pathParamNamingConvention": "UnderscoreCase",
+  "queryParamNamingConvention": "HyphenCase"
+  /*
+    'cookieParamNamingConvention' is not defined.
+        Then it assumes the same value as 'parameterNamingConvention',
+        which is explicitly defined as 'HyphenCase'.
+   */
+}
+```
 
 ## Supported Extensions
 

--- a/cli/src/test/java/org/openapitools/openapistylevalidator/cli/OptionManagerTest.java
+++ b/cli/src/test/java/org/openapitools/openapistylevalidator/cli/OptionManagerTest.java
@@ -133,6 +133,67 @@ class OptionManagerTest {
                 ValidatorParameters.NamingConvention.CamelCase, parameters.getPropertyNamingConvention());
     }
 
+    /* begin - tests for issue #367 */
+    @Test
+    void shouldParseDetailedParameterNamingConventionOptions() throws Exception {
+        ValidatorParameters parameters = subject.getOptionalValidatorParametersOrDefault(withOptions("detailedParameterNamingConvention"));
+
+        Assertions.assertEquals(true, parameters.isValidateNaming());
+        Assertions.assertEquals(ValidatorParameters.NamingConvention.HyphenCase, parameters.getPathNamingConvention());
+        Assertions.assertEquals(
+                ValidatorParameters.NamingConvention.CamelCase, parameters.getParameterNamingConvention());
+        Assertions.assertEquals(
+                ValidatorParameters.NamingConvention.CamelCase, parameters.getPropertyNamingConvention());
+        Assertions.assertEquals(
+                ValidatorParameters.NamingConvention.HyphenCase, parameters.getPathParamNamingConvention());
+        Assertions.assertEquals(
+                ValidatorParameters.NamingConvention.HyphenCase, parameters.getQueryParamNamingConvention());
+        Assertions.assertEquals(
+                ValidatorParameters.NamingConvention.HyphenCase, parameters.getCookieParamNamingConvention());
+    }
+
+    @Test
+    /**
+     * When only the 'parameterNamingConvention' naming convention option is set, it should rule over all parameters types.
+     * Note that 'getPathParamNamingConvention', 'getQueryParamNamingConvention' and 'getCookieParamNamingConvention'
+     * must return the same naming convention returned for 'getParameterNamingConvention'.
+     */
+    void shouldSetAllParametersNamingConventionUnderSameNameConvention() throws Exception {
+        ValidatorParameters parameters = subject.getOptionalValidatorParametersOrDefault(withOptions("alternative"));
+
+        Assertions.assertEquals(true, parameters.isValidateNaming());
+        Assertions.assertEquals(ValidatorParameters.NamingConvention.CamelCase, parameters.getPathNamingConvention());
+        Assertions.assertEquals(
+                ValidatorParameters.NamingConvention.HyphenCase, parameters.getParameterNamingConvention());
+        Assertions.assertEquals(
+                ValidatorParameters.NamingConvention.HyphenCase, parameters.getPropertyNamingConvention());
+        Assertions.assertEquals(parameters.getParameterNamingConvention(), parameters.getPathParamNamingConvention());
+        Assertions.assertEquals(parameters.getParameterNamingConvention(), parameters.getQueryParamNamingConvention());
+        Assertions.assertEquals(parameters.getParameterNamingConvention(), parameters.getCookieParamNamingConvention());
+    }
+
+    @Test
+    /**
+     * If 'parameterNamingConvention' naming convention option is set and another naming convention for specific parameters
+     * (query, path or cookie) is also set, the getters must return the specified values.
+     * The parameters which hadn't had their naming conventions explicitly specified, will be ruled by the
+     * 'parameterNamingConvention' option.
+     */
+    void shouldParseCoexistingParameterNamingConventionOptions() throws Exception {
+        ValidatorParameters parameters = subject.getOptionalValidatorParametersOrDefault(withOptions("parameterNamingConventionCoexistence"));
+
+        Assertions.assertEquals(true, parameters.isValidateNaming());
+        Assertions.assertEquals(ValidatorParameters.NamingConvention.HyphenCase, parameters.getPathNamingConvention());
+        Assertions.assertEquals(
+                ValidatorParameters.NamingConvention.UnderscoreUpperCase, parameters.getParameterNamingConvention());
+        Assertions.assertEquals(parameters.getParameterNamingConvention(), parameters.getPathParamNamingConvention());
+        Assertions.assertEquals(
+                ValidatorParameters.NamingConvention.HyphenCase, parameters.getQueryParamNamingConvention());
+        Assertions.assertEquals(
+                ValidatorParameters.NamingConvention.HyphenCase, parameters.getCookieParamNamingConvention());
+    }
+    /* end - tests for issue #367 */
+
     private CommandLine withOptions(String fileName) throws Exception {
         DefaultParser parser = new DefaultParser();
         Options options = subject.getOptions();

--- a/cli/src/test/java/org/openapitools/openapistylevalidator/cli/OptionManagerTest.java
+++ b/cli/src/test/java/org/openapitools/openapistylevalidator/cli/OptionManagerTest.java
@@ -136,7 +136,8 @@ class OptionManagerTest {
     /* begin - tests for issue #367 */
     @Test
     void shouldParseDetailedParameterNamingConventionOptions() throws Exception {
-        ValidatorParameters parameters = subject.getOptionalValidatorParametersOrDefault(withOptions("detailedParameterNamingConvention"));
+        ValidatorParameters parameters =
+                subject.getOptionalValidatorParametersOrDefault(withOptions("detailedParameterNamingConvention"));
 
         Assertions.assertEquals(true, parameters.isValidateNaming());
         Assertions.assertEquals(ValidatorParameters.NamingConvention.HyphenCase, parameters.getPathNamingConvention());
@@ -180,7 +181,8 @@ class OptionManagerTest {
      * 'parameterNamingConvention' option.
      */
     void shouldParseCoexistingParameterNamingConventionOptions() throws Exception {
-        ValidatorParameters parameters = subject.getOptionalValidatorParametersOrDefault(withOptions("parameterNamingConventionCoexistence"));
+        ValidatorParameters parameters =
+                subject.getOptionalValidatorParametersOrDefault(withOptions("parameterNamingConventionCoexistence"));
 
         Assertions.assertEquals(true, parameters.isValidateNaming());
         Assertions.assertEquals(ValidatorParameters.NamingConvention.HyphenCase, parameters.getPathNamingConvention());

--- a/cli/src/test/java/org/openapitools/openapistylevalidator/cli/ValidationInitiatorTest.java
+++ b/cli/src/test/java/org/openapitools/openapistylevalidator/cli/ValidationInitiatorTest.java
@@ -319,11 +319,11 @@ class ValidationInitiatorTest {
         Assertions.assertAll(
                 () -> assertEquals(3, errorList.size()),
                 () -> assertEquals(
-                        "*ERROR* in path POST /some_path/{some_id} 'some_id' -> parameter should be in "
+                        "*ERROR* in path POST /some_path/{some_id} 'some_id' -> path parameter should be in "
                                 + expectedPathParameterConvention,
                         errorList.get(0).toString()),
                 () -> assertEquals(
-                        "*ERROR* in path POST /some_path/{some_id} 'some_name' -> parameter should be in "
+                        "*ERROR* in path POST /some_path/{some_id} 'some_name' -> query parameter should be in "
                                 + expectedQueryParameterConvention,
                         errorList.get(1).toString()),
                 () -> assertEquals(

--- a/cli/src/test/resources/detailedParameterNamingConvention.json
+++ b/cli/src/test/resources/detailedParameterNamingConvention.json
@@ -1,0 +1,5 @@
+{
+    "pathParamNamingConvention": "HyphenCase",
+    "queryParamNamingConvention": "HyphenCase",
+    "cookieParamNamingConvention": "HyphenCase"
+}

--- a/cli/src/test/resources/parameterNamingConventionCoexistence.json
+++ b/cli/src/test/resources/parameterNamingConventionCoexistence.json
@@ -1,0 +1,5 @@
+{
+    "queryParamNamingConvention": "HyphenCase",
+    "cookieParamNamingConvention": "HyphenCase",
+    "parameterNamingConvention": "UnderscoreUpperCase"
+}

--- a/gradle-plugin/src/main/java/org/openapitools/openapistylevalidator/gradle/OpenAPIStyleValidatorTask.java
+++ b/gradle-plugin/src/main/java/org/openapitools/openapistylevalidator/gradle/OpenAPIStyleValidatorTask.java
@@ -39,6 +39,9 @@ public class OpenAPIStyleValidatorTask extends DefaultTask {
     private NamingConvention parameterNamingConvention = NamingConvention.CamelCase;
     private NamingConvention headerNamingConvention = NamingConvention.UnderscoreUpperCase;
     private NamingConvention propertyNamingConvention = NamingConvention.CamelCase;
+    private NamingConvention queryParamNamingConvention = NamingConvention.CamelCase;
+    private NamingConvention pathParamNamingConvention = NamingConvention.CamelCase;
+    private NamingConvention cookieParamNamingConvention = NamingConvention.CamelCase;
 
     public OpenAPIStyleValidatorTask() {
         this.setGroup("Verification");
@@ -162,6 +165,21 @@ public class OpenAPIStyleValidatorTask extends DefaultTask {
         this.propertyNamingConvention = propertyNamingConvention;
     }
 
+    @Option(option = ValidatorParameters.PROPERTY_NAMING_CONVENTION, description = "Naming convention for path parameters")
+    public void setPathParamNamingConvention(NamingConvention pathParamNamingConvention) {
+        this.pathParamNamingConvention = pathParamNamingConvention;
+    }
+
+    @Option(option = ValidatorParameters.PROPERTY_NAMING_CONVENTION, description = "Naming convention for query parameters")
+    public void setQueryParamNamingConvention(NamingConvention queryParamNamingConvention) {
+        this.queryParamNamingConvention = queryParamNamingConvention;
+    }
+
+    @Option(option = ValidatorParameters.PROPERTY_NAMING_CONVENTION, description = "Naming convention for cookie parameters")
+    public void setCookieParamNamingConvention(NamingConvention cookieParamNamingConvention) {
+        this.cookieParamNamingConvention = cookieParamNamingConvention;
+    }
+
     public ValidatorParameters createValidatorParameters() {
         ValidatorParameters parameters = new ValidatorParameters();
         parameters.setValidateInfoLicense(validateInfoLicense);
@@ -181,6 +199,9 @@ public class OpenAPIStyleValidatorTask extends DefaultTask {
         parameters.setParameterNamingConvention(parameterNamingConvention);
         parameters.setHeaderNamingConvention(headerNamingConvention);
         parameters.setPropertyNamingConvention(propertyNamingConvention);
+        parameters.setPathParamNamingConvention(pathParamNamingConvention);
+        parameters.setQueryParamNamingConvention(queryParamNamingConvention);
+        parameters.setCookieParamNamingConvention(cookieParamNamingConvention);
         return parameters;
     }
 

--- a/lib/src/main/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidator.java
+++ b/lib/src/main/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidator.java
@@ -240,17 +240,45 @@ public class OpenApiSpecStyleValidator {
                                                         method);
                                             }
                                         } else {
-                                            isValid = namingValidator.isNamingValid(
-                                                    opParam.getName(), parameters.getParameterNamingConvention());
-                                            if (!isValid) {
-                                                errorAggregator.logOperationBadNaming(
-                                                        opParam.getName(),
-                                                        "parameter",
-                                                        parameters
-                                                                .getParameterNamingConvention()
-                                                                .getDesignation(),
-                                                        key,
-                                                        method);
+                                            if (opParam.getIn() == Parameter.In.QUERY) {
+                                                isValid = namingValidator.isNamingValid(
+                                                    opParam.getName(), parameters.getQueryParamNamingConvention());
+                                                if (!isValid) {
+                                                    errorAggregator.logOperationBadNaming(
+                                                            opParam.getName(),
+                                                            "query parameter",
+                                                            parameters
+                                                                    .getQueryParamNamingConvention()
+                                                                    .getDesignation(),
+                                                            key,
+                                                            method);
+                                                }
+                                            } else if (opParam.getIn() == Parameter.In.PATH) {
+                                                isValid = namingValidator.isNamingValid(
+                                                    opParam.getName(), parameters.getPathParamNamingConvention());
+                                                if (!isValid) {
+                                                    errorAggregator.logOperationBadNaming(
+                                                            opParam.getName(),
+                                                            "path parameter",
+                                                            parameters
+                                                                    .getPathParamNamingConvention()
+                                                                    .getDesignation(),
+                                                            key,
+                                                            method);
+                                                }
+                                            } else if (opParam.getIn() == Parameter.In.COOKIE) {
+                                                isValid = namingValidator.isNamingValid(
+                                                    opParam.getName(), parameters.getCookieParamNamingConvention());
+                                                if (!isValid) {
+                                                    errorAggregator.logOperationBadNaming(
+                                                            opParam.getName(),
+                                                            "cookie parameter",
+                                                            parameters
+                                                                    .getCookieParamNamingConvention()
+                                                                    .getDesignation(),
+                                                            key,
+                                                            method);
+                                                }
                                             }
                                         }
                                     }

--- a/lib/src/main/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidator.java
+++ b/lib/src/main/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidator.java
@@ -9,6 +9,7 @@ import org.eclipse.microprofile.openapi.models.info.Info;
 import org.eclipse.microprofile.openapi.models.info.License;
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
+import org.openapitools.openapistylevalidator.ValidatorParameters.NamingConvention;
 import org.openapitools.openapistylevalidator.styleerror.StyleError;
 
 public class OpenApiSpecStyleValidator {
@@ -225,60 +226,39 @@ public class OpenApiSpecStyleValidator {
                                     }
 
                                     if (shouldValidate && opParam.getRef() == null) {
-                                        boolean isValid = false;
                                         if (opParam.getIn() == Parameter.In.HEADER) {
-                                            isValid = namingValidator.isNamingValid(
-                                                    opParam.getName(), parameters.getHeaderNamingConvention());
-                                            if (!isValid) {
-                                                errorAggregator.logOperationBadNaming(
-                                                        opParam.getName(),
-                                                        "header",
-                                                        parameters
-                                                                .getHeaderNamingConvention()
-                                                                .getDesignation(),
-                                                        key,
-                                                        method);
-                                            }
+                                            validateParamNaming(
+                                                    opParam.getName(),
+                                                    "header",
+                                                    parameters.getHeaderNamingConvention(),
+                                                    key,
+                                                    method);
+
                                         } else {
                                             if (opParam.getIn() == Parameter.In.QUERY) {
-                                                isValid = namingValidator.isNamingValid(
-                                                        opParam.getName(), parameters.getQueryParamNamingConvention());
-                                                if (!isValid) {
-                                                    errorAggregator.logOperationBadNaming(
-                                                            opParam.getName(),
-                                                            "query parameter",
-                                                            parameters
-                                                                    .getQueryParamNamingConvention()
-                                                                    .getDesignation(),
-                                                            key,
-                                                            method);
-                                                }
+                                                validateParamNaming(
+                                                        opParam.getName(),
+                                                        "query parameter",
+                                                        parameters.getQueryParamNamingConvention(),
+                                                        key,
+                                                        method);
+
                                             } else if (opParam.getIn() == Parameter.In.PATH) {
-                                                isValid = namingValidator.isNamingValid(
-                                                        opParam.getName(), parameters.getPathParamNamingConvention());
-                                                if (!isValid) {
-                                                    errorAggregator.logOperationBadNaming(
-                                                            opParam.getName(),
-                                                            "path parameter",
-                                                            parameters
-                                                                    .getPathParamNamingConvention()
-                                                                    .getDesignation(),
-                                                            key,
-                                                            method);
-                                                }
+                                                validateParamNaming(
+                                                        opParam.getName(),
+                                                        "path parameter",
+                                                        parameters.getPathParamNamingConvention(),
+                                                        key,
+                                                        method);
+                                                
                                             } else if (opParam.getIn() == Parameter.In.COOKIE) {
-                                                isValid = namingValidator.isNamingValid(
-                                                        opParam.getName(), parameters.getCookieParamNamingConvention());
-                                                if (!isValid) {
-                                                    errorAggregator.logOperationBadNaming(
-                                                            opParam.getName(),
-                                                            "cookie parameter",
-                                                            parameters
-                                                                    .getCookieParamNamingConvention()
-                                                                    .getDesignation(),
-                                                            key,
-                                                            method);
-                                                }
+                                                validateParamNaming(
+                                                        opParam.getName(),
+                                                        "cookie parameter",
+                                                        parameters.getCookieParamNamingConvention(),
+                                                        key,
+                                                        method);
+
                                             }
                                         }
                                     }
@@ -304,6 +284,25 @@ public class OpenApiSpecStyleValidator {
                     }
                 }
             }
+        }
+    }
+
+    private void validateParamNaming(
+            String paramName,
+            String variableType,
+            NamingConvention namingConvention,
+            String key,
+            PathItem.HttpMethod method) {
+        boolean isValid = namingValidator.isNamingValid(
+                paramName, namingConvention);
+        if (!isValid) {
+            errorAggregator.logOperationBadNaming(
+                    paramName,
+                    variableType,
+                    namingConvention
+                            .getDesignation(),
+                    key,
+                    method);
         }
     }
 }

--- a/lib/src/main/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidator.java
+++ b/lib/src/main/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidator.java
@@ -250,7 +250,7 @@ public class OpenApiSpecStyleValidator {
                                                         parameters.getPathParamNamingConvention(),
                                                         key,
                                                         method);
-                                                
+
                                             } else if (opParam.getIn() == Parameter.In.COOKIE) {
                                                 validateParamNaming(
                                                         opParam.getName(),
@@ -258,7 +258,6 @@ public class OpenApiSpecStyleValidator {
                                                         parameters.getCookieParamNamingConvention(),
                                                         key,
                                                         method);
-
                                             }
                                         }
                                     }
@@ -293,16 +292,10 @@ public class OpenApiSpecStyleValidator {
             NamingConvention namingConvention,
             String key,
             PathItem.HttpMethod method) {
-        boolean isValid = namingValidator.isNamingValid(
-                paramName, namingConvention);
+        boolean isValid = namingValidator.isNamingValid(paramName, namingConvention);
         if (!isValid) {
             errorAggregator.logOperationBadNaming(
-                    paramName,
-                    variableType,
-                    namingConvention
-                            .getDesignation(),
-                    key,
-                    method);
+                    paramName, variableType, namingConvention.getDesignation(), key, method);
         }
     }
 }

--- a/lib/src/main/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidator.java
+++ b/lib/src/main/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidator.java
@@ -242,7 +242,7 @@ public class OpenApiSpecStyleValidator {
                                         } else {
                                             if (opParam.getIn() == Parameter.In.QUERY) {
                                                 isValid = namingValidator.isNamingValid(
-                                                    opParam.getName(), parameters.getQueryParamNamingConvention());
+                                                        opParam.getName(), parameters.getQueryParamNamingConvention());
                                                 if (!isValid) {
                                                     errorAggregator.logOperationBadNaming(
                                                             opParam.getName(),
@@ -255,7 +255,7 @@ public class OpenApiSpecStyleValidator {
                                                 }
                                             } else if (opParam.getIn() == Parameter.In.PATH) {
                                                 isValid = namingValidator.isNamingValid(
-                                                    opParam.getName(), parameters.getPathParamNamingConvention());
+                                                        opParam.getName(), parameters.getPathParamNamingConvention());
                                                 if (!isValid) {
                                                     errorAggregator.logOperationBadNaming(
                                                             opParam.getName(),
@@ -268,7 +268,7 @@ public class OpenApiSpecStyleValidator {
                                                 }
                                             } else if (opParam.getIn() == Parameter.In.COOKIE) {
                                                 isValid = namingValidator.isNamingValid(
-                                                    opParam.getName(), parameters.getCookieParamNamingConvention());
+                                                        opParam.getName(), parameters.getCookieParamNamingConvention());
                                                 if (!isValid) {
                                                     errorAggregator.logOperationBadNaming(
                                                             opParam.getName(),

--- a/lib/src/main/java/org/openapitools/openapistylevalidator/ValidatorParameters.java
+++ b/lib/src/main/java/org/openapitools/openapistylevalidator/ValidatorParameters.java
@@ -226,7 +226,7 @@ public class ValidatorParameters {
         if (!this.queryParamNamingConventionWasExplicitlySet) {
             this.queryParamNamingConvention = parameterNamingConvention;
         }
-        
+
         return this;
     }
 

--- a/lib/src/main/java/org/openapitools/openapistylevalidator/ValidatorParameters.java
+++ b/lib/src/main/java/org/openapitools/openapistylevalidator/ValidatorParameters.java
@@ -21,6 +21,9 @@ public class ValidatorParameters {
     public static final String PARAMETER_NAMING_CONVENTION = "parameterNamingConvention";
     public static final String HEADER_NAMING_CONVENTION = "headerNamingConvention";
     public static final String PROPERTY_NAMING_CONVENTION = "propertyNamingConvention";
+    public static final String QUERY_PARAM_NAMING_CONVENTION = "queryParamNamingConvention";
+    public static final String PATH_PARAM_NAMING_CONVENTION = "pathParamNamingConvention";
+    public static final String COOKIE_PARAM_NAMING_CONVENTION = "cookieParamNamingConvention";
 
     public static enum NamingConvention {
         UnderscoreCase("underscore_case"),
@@ -64,6 +67,13 @@ public class ValidatorParameters {
     private NamingConvention parameterNamingConvention = NamingConvention.CamelCase;
     private NamingConvention headerNamingConvention = NamingConvention.UnderscoreUpperCase;
     private NamingConvention propertyNamingConvention = NamingConvention.CamelCase;
+    private NamingConvention queryParamNamingConvention = NamingConvention.CamelCase;
+    private NamingConvention pathParamNamingConvention = NamingConvention.CamelCase;
+    private NamingConvention cookieParamNamingConvention = NamingConvention.CamelCase;
+
+    private boolean queryParamNamingConventionWasExplicitlySet = false;
+    private boolean pathParamNamingConventionWasExplicitlySet = false;
+    private boolean cookieParamNamingConventionWasExplicitlySet = false;
 
     public ValidatorParameters() {
         // For Gson
@@ -129,6 +139,18 @@ public class ValidatorParameters {
         return propertyNamingConvention;
     }
 
+    public NamingConvention getQueryParamNamingConvention() {
+        return queryParamNamingConvention;
+    }
+
+    public NamingConvention getPathParamNamingConvention() {
+        return pathParamNamingConvention;
+    }
+
+    public NamingConvention getCookieParamNamingConvention() {
+        return cookieParamNamingConvention;
+    }
+
     public ValidatorParameters setValidateInfoLicense(boolean validateInfoLicense) {
         this.validateInfoLicense = validateInfoLicense;
         return this;
@@ -191,6 +213,20 @@ public class ValidatorParameters {
 
     public ValidatorParameters setParameterNamingConvention(NamingConvention parameterNamingConvention) {
         this.parameterNamingConvention = parameterNamingConvention;
+
+        // Setting the higher level parameter naming convention overrides the sub-conventions
+        if (!this.cookieParamNamingConventionWasExplicitlySet) {
+            this.cookieParamNamingConvention = parameterNamingConvention;
+        }
+
+        if (!this.pathParamNamingConventionWasExplicitlySet) {
+            this.pathParamNamingConvention = parameterNamingConvention;
+        }
+
+        if (!this.queryParamNamingConventionWasExplicitlySet) {
+            this.queryParamNamingConvention = parameterNamingConvention;
+        }
+        
         return this;
     }
 
@@ -201,6 +237,24 @@ public class ValidatorParameters {
 
     public ValidatorParameters setPropertyNamingConvention(NamingConvention propertyNamingConvention) {
         this.propertyNamingConvention = propertyNamingConvention;
+        return this;
+    }
+
+    public ValidatorParameters setQueryParamNamingConvention(NamingConvention queryParamNamingConvention) {
+        this.queryParamNamingConvention = queryParamNamingConvention;
+        this.queryParamNamingConventionWasExplicitlySet = true;
+        return this;
+    }
+
+    public ValidatorParameters setPathParamNamingConvention(NamingConvention pathParamNamingConvention) {
+        this.pathParamNamingConvention = pathParamNamingConvention;
+        this.pathParamNamingConventionWasExplicitlySet = true;
+        return this;
+    }
+
+    public ValidatorParameters setCookieParamNamingConvention(NamingConvention cookieParamNamingConvention) {
+        this.cookieParamNamingConvention = cookieParamNamingConvention;
+        this.cookieParamNamingConventionWasExplicitlySet = true;
         return this;
     }
 
@@ -240,7 +294,10 @@ public class ValidatorParameters {
                         + "pathNamingConvention=%s, "
                         + "headerNamingConvention=%s, "
                         + "parameterNamingConvention=%s, "
-                        + "propertyNamingConvention=%s"
+                        + "propertyNamingConvention=%s, "
+                        + "queryParamNamingConvention=%s, "
+                        + "pathParamNamingConvention=%s, "
+                        + "cookieParamNamingConvention=%s"
                         + "]",
                 validateInfoLicense,
                 validateInfoDescription,
@@ -258,6 +315,9 @@ public class ValidatorParameters {
                 pathNamingConvention,
                 headerNamingConvention,
                 parameterNamingConvention,
-                propertyNamingConvention);
+                propertyNamingConvention,
+                queryParamNamingConvention,
+                pathParamNamingConvention,
+                cookieParamNamingConvention);
     }
 }

--- a/lib/src/test/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidatorTest.java
+++ b/lib/src/test/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidatorTest.java
@@ -2,6 +2,7 @@ package org.openapitools.openapistylevalidator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -9,10 +10,12 @@ import org.eclipse.microprofile.openapi.OASFactory;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.media.Schema;
 import org.eclipse.microprofile.openapi.models.media.Schema.SchemaType;
+import org.eclipse.microprofile.openapi.models.parameters.Parameter.In;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.openapitools.openapistylevalidator.ValidatorParameters.NamingConvention;
 import org.openapitools.openapistylevalidator.styleerror.StyleError;
 
 class OpenApiSpecStyleValidatorTest {
@@ -263,6 +266,150 @@ class OpenApiSpecStyleValidatorTest {
                         errors.get(0).toString()));
     }
 
+    /* tests for naming convention parameters */
+    @Test
+    void shouldReportPathNamingConventionError() {
+        OpenAPI openAPI = createValidOpenAPI();
+        openAPI.paths(
+                openAPI.getPaths()
+                .addPathItem(
+                        "/foo_path",
+                        OASFactory.createPathItem()
+                        .GET(OASFactory.createOperation()
+                                .operationId("pingGet")
+                                .summary("A simple get call")
+                                .description(
+                                        "When this method is called, the server answers with 200 OKs")
+                                .addTag("demo")
+                                .responses(OASFactory.createAPIResponses()
+                                        .addAPIResponse(
+                                                "200",
+                                                OASFactory.createAPIResponse()
+                                                        .description("OK"))))));
+
+        OpenApiSpecStyleValidator validator = new OpenApiSpecStyleValidator(openAPI);
+
+        List<StyleError> errors = validator.validate(new ValidatorParameters());
+        Assertions.assertAll(
+                () -> assertEquals(1, errors.size()),
+                () -> assertEquals(
+                        "*ERROR* in path /foo_path 'foo_path' -> path should be in hyphen-case",
+                        errors.get(0).toString()));
+    }
+
+    @Test
+    void shouldReportParameterNamingConventionError() {
+        OpenAPI openAPI = createValidOpenAPI();
+
+        OpenApiSpecStyleValidator validator = new OpenApiSpecStyleValidator(openAPI);
+
+        ValidatorParameters validatorParams = new ValidatorParameters();
+        validatorParams.setParameterNamingConvention(NamingConvention.HyphenCase);
+        List<StyleError> errors = validator.validate(validatorParams);
+        Assertions.assertAll(
+                () -> assertEquals(3, errors.size()),
+                () -> assertEquals(
+                        "*ERROR* in path POST /foo/{pathParamOne} 'pathParamOne' -> path parameter should be in hyphen-case",
+                        errors.get(0).toString()),
+                () -> assertEquals(
+                        "*ERROR* in path POST /foo/{pathParamOne} 'queryParamOne' -> query parameter should be in hyphen-case",
+                        errors.get(1).toString()),
+                () -> assertEquals(
+                        "*ERROR* in path POST /foo/{pathParamOne} 'cookieParamOne' -> cookie parameter should be in hyphen-case",
+                        errors.get(2).toString()));
+    }
+
+    @Test
+    void shouldReportHeaderNamingConventionError() {
+        OpenAPI openAPI = createValidOpenAPI();
+
+        OpenApiSpecStyleValidator validator = new OpenApiSpecStyleValidator(openAPI);
+
+        ValidatorParameters validatorParams = new ValidatorParameters();
+        validatorParams.setHeaderNamingConvention(NamingConvention.HyphenCase);
+        List<StyleError> errors = validator.validate(validatorParams);
+        Assertions.assertAll(
+                () -> assertEquals(1, errors.size()),
+                () -> assertEquals(
+                        "*ERROR* in path POST /foo/{pathParamOne} 'HEADER_PARAM_ONE' -> header should be in hyphen-case",
+                        errors.get(0).toString()));
+    }
+
+    @Test
+    void shouldReportPropertyNamingConventionError() {
+        OpenAPI openAPI = createValidOpenAPI();
+
+        OpenApiSpecStyleValidator validator = new OpenApiSpecStyleValidator(openAPI);
+
+        ValidatorParameters validatorParams = new ValidatorParameters();
+        validatorParams.setPropertyNamingConvention(NamingConvention.HyphenCase);
+        List<StyleError> errors = validator.validate(validatorParams);
+        Assertions.assertAll(
+                () -> assertEquals(4, errors.size()),
+                () -> assertEquals(
+                        "*ERROR* in model FooSchema 'fooPropertyOne' -> property should be in hyphen-case",
+                        errors.get(0).toString()),
+                () -> assertEquals(
+                        "*ERROR* in model FooSchema 'fooPropertyTwo' -> property should be in hyphen-case",
+                        errors.get(1).toString()),
+                () -> assertEquals(
+                        "*ERROR* in model BazSchema 'bazPropertyTwo' -> property should be in hyphen-case",
+                        errors.get(2).toString()),
+                () -> assertEquals(
+                        "*ERROR* in model BazSchema 'bazPropertyOne' -> property should be in hyphen-case",
+                        errors.get(3).toString()));
+    }
+
+    /* begin - tests for issue #367 */
+    @Test
+    void shouldReportQueryParamNamingConventionError() {
+        OpenAPI openAPI = createValidOpenAPI();
+
+        OpenApiSpecStyleValidator validator = new OpenApiSpecStyleValidator(openAPI);
+
+        ValidatorParameters validatorParams = new ValidatorParameters();
+        validatorParams.setQueryParamNamingConvention(NamingConvention.HyphenCase);
+        List<StyleError> errors = validator.validate(validatorParams);
+        Assertions.assertAll(
+                () -> assertEquals(1, errors.size()),
+                () -> assertEquals(
+                        "*ERROR* in path POST /foo/{pathParamOne} 'queryParamOne' -> query parameter should be in hyphen-case",
+                        errors.get(0).toString()));
+    }
+
+    @Test
+    void shouldReportPathParamNamingConventionError() {
+        OpenAPI openAPI = createValidOpenAPI();
+
+        OpenApiSpecStyleValidator validator = new OpenApiSpecStyleValidator(openAPI);
+
+        ValidatorParameters validatorParams = new ValidatorParameters();
+        validatorParams.setPathParamNamingConvention(NamingConvention.HyphenCase);
+        List<StyleError> errors = validator.validate(validatorParams);
+        Assertions.assertAll(
+                () -> assertEquals(1, errors.size()),
+                () -> assertEquals(
+                        "*ERROR* in path POST /foo/{pathParamOne} 'pathParamOne' -> path parameter should be in hyphen-case",
+                        errors.get(0).toString()));
+    }
+
+    @Test
+    void shouldReportCookieParamNamingConventionError() {
+        OpenAPI openAPI = createValidOpenAPI();
+
+        OpenApiSpecStyleValidator validator = new OpenApiSpecStyleValidator(openAPI);
+
+        ValidatorParameters validatorParams = new ValidatorParameters();
+        validatorParams.setCookieParamNamingConvention(NamingConvention.HyphenCase);
+        List<StyleError> errors = validator.validate(validatorParams);
+        Assertions.assertAll(
+                () -> assertEquals(1, errors.size()),
+                () -> assertEquals(
+                        "*ERROR* in path POST /foo/{pathParamOne} 'cookieParamOne' -> cookie parameter should be in hyphen-case",
+                        errors.get(0).toString()));
+    }
+    /* end - tests for issue #367 */
+
     private static OpenAPI createValidOpenAPI() {
         return OASFactory.createOpenAPI()
                 .openapi("3.0.1")
@@ -290,6 +437,110 @@ class OpenApiSpecStyleValidatorTest {
                                                         .addAPIResponse(
                                                                 "200",
                                                                 OASFactory.createAPIResponse()
-                                                                        .description("OK"))))));
+                                                                        .description("OK")))))
+                        .addPathItem(
+                                "/foo/{pathParamOne}",
+                                OASFactory.createPathItem()
+                                        .POST(OASFactory.createOperation()
+                                                .operationId("fooPost")
+                                                .summary("A simple post call")
+                                                .description(
+                                                        "When this method is called, the server answers with 200 OKs")
+                                                .addTag("demo")
+                                                .addParameter(OASFactory.createParameter()
+                                                        .name("pathParamOne")
+                                                        .in(In.PATH)
+                                                        .required(true)
+                                                        .description("Foo path param number one"))
+                                                .addParameter(OASFactory.createParameter()
+                                                        .name("queryParamOne")
+                                                        .in(In.QUERY)
+                                                        .required(true)
+                                                        .description("Foo query param number one"))
+                                                .addParameter(OASFactory.createParameter()
+                                                        .name("HEADER_PARAM_ONE")
+                                                        .in(In.HEADER)
+                                                        .required(true)
+                                                        .description("Foo header param number one"))
+                                                .addParameter(OASFactory.createParameter()
+                                                        .name("cookieParamOne")
+                                                        .in(In.COOKIE)
+                                                        .required(true)
+                                                        .description("Foo cookie param number one"))
+                                                .requestBody(OASFactory.createRequestBody()
+                                                        .description("Foo request body")
+                                                        .required(true)
+                                                        .content(OASFactory.createContent()
+                                                                .addMediaType(
+                                                                        "application/json",
+                                                                        OASFactory.createMediaType()
+                                                                                .schema(OASFactory.createSchema()
+                                                                                        .ref("#/components/schemas/FooSchema")))))
+                                                .responses(OASFactory.createAPIResponses()
+                                                        .addAPIResponse(
+                                                                "200",
+                                                                OASFactory.createAPIResponse()
+                                                                        .description("OK")))))
+                        .addPathItem(
+                                "/baz",
+                                OASFactory.createPathItem()
+                                        .POST(OASFactory.createOperation()
+                                                .operationId("bazPost")
+                                                .summary("A simple post call")
+                                                .description(
+                                                        "When this method is called, the server answers with 200 OKs")
+                                                .addTag("demo")
+                                                .requestBody(OASFactory.createRequestBody()
+                                                        .description("Baz request body")
+                                                        .required(true)
+                                                        .content(OASFactory.createContent()
+                                                                .addMediaType(
+                                                                        "application/json",
+                                                                        OASFactory.createMediaType()
+                                                                                .schema(OASFactory.createSchema()
+                                                                                        .ref("#/components/schemas/BazSchema")))))
+                                                .responses(OASFactory.createAPIResponses()
+                                                        .addAPIResponse(
+                                                                "200",
+                                                                OASFactory.createAPIResponse()
+                                                                        .description("OK"))))))
+                        
+                .components(OASFactory.createComponents()
+                        .schemas(new HashMap<String, Schema>() {{
+                                put("FooSchema", OASFactory.createSchema()
+                                        .title("Foo schema title")
+                                        .type(SchemaType.OBJECT)
+                                        .properties(new HashMap<String, Schema>() {{
+                                                put("fooPropertyOne", OASFactory.createSchema()
+                                                        .type(SchemaType.STRING)
+                                                        .example("example1")
+                                                        .description("Simple property description 1"));
+                                                put("fooPropertyTwo", OASFactory.createSchema()
+                                                        .type(SchemaType.INTEGER)
+                                                        .example("example2")
+                                                        .description("Simple property description 2"));
+                                        }})
+                                        .required(new ArrayList<String>() {{
+                                                add("fooPropertyOne");
+                                                add("fooPropertyTwo");
+                                        }}));
+                                put("BazSchema", OASFactory.createSchema()
+                                        .title("Baz schema title")
+                                        .type(SchemaType.OBJECT)
+                                        .properties(new HashMap<String, Schema>() {{
+                                                put("bazPropertyOne", OASFactory.createSchema()
+                                                        .type(SchemaType.STRING)
+                                                        .example("example1")
+                                                        .description("Simple property description 1"));
+                                                put("bazPropertyTwo", OASFactory.createSchema()
+                                                        .type(SchemaType.INTEGER)
+                                                        .example("example2")
+                                                        .description("Simple property description 2"));
+                                        }})
+                                        .required(new ArrayList<String>() {{
+                                                add("bazPropertyOne");
+                                                add("bazPropertyTwo");
+                                        }}));
+                        }}));
     }
 }

--- a/lib/src/test/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidatorTest.java
+++ b/lib/src/test/java/org/openapitools/openapistylevalidator/OpenApiSpecStyleValidatorTest.java
@@ -270,22 +270,20 @@ class OpenApiSpecStyleValidatorTest {
     @Test
     void shouldReportPathNamingConventionError() {
         OpenAPI openAPI = createValidOpenAPI();
-        openAPI.paths(
-                openAPI.getPaths()
+        openAPI.paths(openAPI.getPaths()
                 .addPathItem(
                         "/foo_path",
                         OASFactory.createPathItem()
-                        .GET(OASFactory.createOperation()
-                                .operationId("pingGet")
-                                .summary("A simple get call")
-                                .description(
-                                        "When this method is called, the server answers with 200 OKs")
-                                .addTag("demo")
-                                .responses(OASFactory.createAPIResponses()
-                                        .addAPIResponse(
-                                                "200",
-                                                OASFactory.createAPIResponse()
-                                                        .description("OK"))))));
+                                .GET(OASFactory.createOperation()
+                                        .operationId("pingGet")
+                                        .summary("A simple get call")
+                                        .description("When this method is called, the server answers with 200 OKs")
+                                        .addTag("demo")
+                                        .responses(OASFactory.createAPIResponses()
+                                                .addAPIResponse(
+                                                        "200",
+                                                        OASFactory.createAPIResponse()
+                                                                .description("OK"))))));
 
         OpenApiSpecStyleValidator validator = new OpenApiSpecStyleValidator(openAPI);
 
@@ -467,15 +465,20 @@ class OpenApiSpecStyleValidatorTest {
                                                         .in(In.COOKIE)
                                                         .required(true)
                                                         .description("Foo cookie param number one"))
-                                                .requestBody(OASFactory.createRequestBody()
-                                                        .description("Foo request body")
-                                                        .required(true)
-                                                        .content(OASFactory.createContent()
-                                                                .addMediaType(
-                                                                        "application/json",
-                                                                        OASFactory.createMediaType()
-                                                                                .schema(OASFactory.createSchema()
-                                                                                        .ref("#/components/schemas/FooSchema")))))
+                                                .requestBody(
+                                                        OASFactory.createRequestBody()
+                                                                .description("Foo request body")
+                                                                .required(true)
+                                                                .content(
+                                                                        OASFactory.createContent()
+                                                                                .addMediaType(
+                                                                                        "application/json",
+                                                                                        OASFactory.createMediaType()
+                                                                                                .schema(
+                                                                                                        OASFactory
+                                                                                                                .createSchema()
+                                                                                                                .ref(
+                                                                                                                        "#/components/schemas/FooSchema")))))
                                                 .responses(OASFactory.createAPIResponses()
                                                         .addAPIResponse(
                                                                 "200",
@@ -490,57 +493,82 @@ class OpenApiSpecStyleValidatorTest {
                                                 .description(
                                                         "When this method is called, the server answers with 200 OKs")
                                                 .addTag("demo")
-                                                .requestBody(OASFactory.createRequestBody()
-                                                        .description("Baz request body")
-                                                        .required(true)
-                                                        .content(OASFactory.createContent()
-                                                                .addMediaType(
-                                                                        "application/json",
-                                                                        OASFactory.createMediaType()
-                                                                                .schema(OASFactory.createSchema()
-                                                                                        .ref("#/components/schemas/BazSchema")))))
+                                                .requestBody(
+                                                        OASFactory.createRequestBody()
+                                                                .description("Baz request body")
+                                                                .required(true)
+                                                                .content(
+                                                                        OASFactory.createContent()
+                                                                                .addMediaType(
+                                                                                        "application/json",
+                                                                                        OASFactory.createMediaType()
+                                                                                                .schema(
+                                                                                                        OASFactory
+                                                                                                                .createSchema()
+                                                                                                                .ref(
+                                                                                                                        "#/components/schemas/BazSchema")))))
                                                 .responses(OASFactory.createAPIResponses()
                                                         .addAPIResponse(
                                                                 "200",
                                                                 OASFactory.createAPIResponse()
                                                                         .description("OK"))))))
-                        
-                .components(OASFactory.createComponents()
-                        .schemas(new HashMap<String, Schema>() {{
-                                put("FooSchema", OASFactory.createSchema()
+                .components(OASFactory.createComponents().schemas(new HashMap<String, Schema>() {
+                    {
+                        put(
+                                "FooSchema",
+                                OASFactory.createSchema()
                                         .title("Foo schema title")
                                         .type(SchemaType.OBJECT)
-                                        .properties(new HashMap<String, Schema>() {{
-                                                put("fooPropertyOne", OASFactory.createSchema()
-                                                        .type(SchemaType.STRING)
-                                                        .example("example1")
-                                                        .description("Simple property description 1"));
-                                                put("fooPropertyTwo", OASFactory.createSchema()
-                                                        .type(SchemaType.INTEGER)
-                                                        .example("example2")
-                                                        .description("Simple property description 2"));
-                                        }})
-                                        .required(new ArrayList<String>() {{
+                                        .properties(new HashMap<String, Schema>() {
+                                            {
+                                                put(
+                                                        "fooPropertyOne",
+                                                        OASFactory.createSchema()
+                                                                .type(SchemaType.STRING)
+                                                                .example("example1")
+                                                                .description("Simple property description 1"));
+                                                put(
+                                                        "fooPropertyTwo",
+                                                        OASFactory.createSchema()
+                                                                .type(SchemaType.INTEGER)
+                                                                .example("example2")
+                                                                .description("Simple property description 2"));
+                                            }
+                                        })
+                                        .required(new ArrayList<String>() {
+                                            {
                                                 add("fooPropertyOne");
                                                 add("fooPropertyTwo");
-                                        }}));
-                                put("BazSchema", OASFactory.createSchema()
+                                            }
+                                        }));
+                        put(
+                                "BazSchema",
+                                OASFactory.createSchema()
                                         .title("Baz schema title")
                                         .type(SchemaType.OBJECT)
-                                        .properties(new HashMap<String, Schema>() {{
-                                                put("bazPropertyOne", OASFactory.createSchema()
-                                                        .type(SchemaType.STRING)
-                                                        .example("example1")
-                                                        .description("Simple property description 1"));
-                                                put("bazPropertyTwo", OASFactory.createSchema()
-                                                        .type(SchemaType.INTEGER)
-                                                        .example("example2")
-                                                        .description("Simple property description 2"));
-                                        }})
-                                        .required(new ArrayList<String>() {{
+                                        .properties(new HashMap<String, Schema>() {
+                                            {
+                                                put(
+                                                        "bazPropertyOne",
+                                                        OASFactory.createSchema()
+                                                                .type(SchemaType.STRING)
+                                                                .example("example1")
+                                                                .description("Simple property description 1"));
+                                                put(
+                                                        "bazPropertyTwo",
+                                                        OASFactory.createSchema()
+                                                                .type(SchemaType.INTEGER)
+                                                                .example("example2")
+                                                                .description("Simple property description 2"));
+                                            }
+                                        })
+                                        .required(new ArrayList<String>() {
+                                            {
                                                 add("bazPropertyOne");
                                                 add("bazPropertyTwo");
-                                        }}));
-                        }}));
+                                            }
+                                        }));
+                    }
+                }));
     }
 }

--- a/lib/src/test/java/org/openapitools/openapistylevalidator/ValidatorParametersTest.java
+++ b/lib/src/test/java/org/openapitools/openapistylevalidator/ValidatorParametersTest.java
@@ -39,7 +39,13 @@ class ValidatorParametersTest {
                         ValidatorParameters.NamingConvention.UnderscoreUpperCase,
                         parameters.getHeaderNamingConvention()),
                 () -> assertEquals(
-                        ValidatorParameters.NamingConvention.CamelCase, parameters.getPropertyNamingConvention()));
+                        ValidatorParameters.NamingConvention.CamelCase, parameters.getPropertyNamingConvention()),
+                () -> assertEquals(
+                        ValidatorParameters.NamingConvention.CamelCase, parameters.getQueryParamNamingConvention()),
+                () -> assertEquals(
+                        ValidatorParameters.NamingConvention.CamelCase, parameters.getPathParamNamingConvention()),
+                () -> assertEquals(
+                        ValidatorParameters.NamingConvention.CamelCase, parameters.getCookieParamNamingConvention()));
     }
 
     @Test
@@ -49,7 +55,10 @@ class ValidatorParametersTest {
                 .setPathNamingConvention(ValidatorParameters.NamingConvention.CamelCase)
                 .setParameterNamingConvention(ValidatorParameters.NamingConvention.CamelCase)
                 .setHeaderNamingConvention(ValidatorParameters.NamingConvention.UnderscoreUpperCase)
-                .setPropertyNamingConvention(ValidatorParameters.NamingConvention.CamelCase);
+                .setPropertyNamingConvention(ValidatorParameters.NamingConvention.CamelCase)
+                .setQueryParamNamingConvention(ValidatorParameters.NamingConvention.CamelCase)
+                .setPathParamNamingConvention(ValidatorParameters.NamingConvention.CamelCase)
+                .setCookieParamNamingConvention(ValidatorParameters.NamingConvention.CamelCase);
 
         Assertions.assertAll(
                 () -> assertFalse(parameters.isValidateInfoLicense()),
@@ -73,6 +82,12 @@ class ValidatorParametersTest {
                         ValidatorParameters.NamingConvention.UnderscoreUpperCase,
                         parameters.getHeaderNamingConvention()),
                 () -> assertEquals(
-                        ValidatorParameters.NamingConvention.CamelCase, parameters.getPropertyNamingConvention()));
+                        ValidatorParameters.NamingConvention.CamelCase, parameters.getPropertyNamingConvention()),
+                () -> assertEquals(
+                        ValidatorParameters.NamingConvention.CamelCase, parameters.getQueryParamNamingConvention()),
+                () -> assertEquals(
+                        ValidatorParameters.NamingConvention.CamelCase, parameters.getPathParamNamingConvention()),
+                () -> assertEquals(
+                        ValidatorParameters.NamingConvention.CamelCase, parameters.getCookieParamNamingConvention()));
     }
 }

--- a/maven-plugin/src/main/java/org/openapitools/openapistylevalidator/maven/OpenAPIStyleValidatorMojo.java
+++ b/maven-plugin/src/main/java/org/openapitools/openapistylevalidator/maven/OpenAPIStyleValidatorMojo.java
@@ -75,6 +75,15 @@ public class OpenAPIStyleValidatorMojo extends AbstractMojo {
     @Parameter(property = ValidatorParameters.PROPERTY_NAMING_CONVENTION, defaultValue = "CamelCase")
     private NamingConvention propertyNamingConvention = NamingConvention.CamelCase;
 
+    @Parameter(property = ValidatorParameters.PATH_PARAM_NAMING_CONVENTION, defaultValue = "CamelCase")
+    private NamingConvention pathParamNamingConvention = NamingConvention.CamelCase;
+
+    @Parameter(property = ValidatorParameters.QUERY_PARAM_NAMING_CONVENTION, defaultValue = "CamelCase")
+    private NamingConvention queryParamNamingConvention = NamingConvention.CamelCase;
+
+    @Parameter(property = ValidatorParameters.COOKIE_PARAM_NAMING_CONVENTION, defaultValue = "CamelCase")
+    private NamingConvention cookieParamNamingConvention = NamingConvention.CamelCase;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (inputFile == null) {
@@ -121,6 +130,9 @@ public class OpenAPIStyleValidatorMojo extends AbstractMojo {
         parameters.setHeaderNamingConvention(headerNamingConvention);
         parameters.setParameterNamingConvention(parameterNamingConvention);
         parameters.setPropertyNamingConvention(propertyNamingConvention);
+        parameters.setPathParamNamingConvention(pathParamNamingConvention);
+        parameters.setQueryParamNamingConvention(queryParamNamingConvention);
+        parameters.setCookieParamNamingConvention(cookieParamNamingConvention);
         return parameters;
     }
 }

--- a/maven-plugin/src/test/java/org/openapitools/openapistylevalidator/maven/IntegrationTest.java
+++ b/maven-plugin/src/test/java/org/openapitools/openapistylevalidator/maven/IntegrationTest.java
@@ -96,8 +96,8 @@ public class IntegrationTest {
         .assertLogText("Validating spec:")
         .assertLogText(Paths.get("cli", "src", "test", "resources", "some.yaml").toString())
         .assertLogText("OpenAPI Specification does not meet the requirements. Issues:")
-        .assertLogText("*ERROR* in path POST /some_path/{some_id} 'some_id' -> parameter should be in camelCase")
-        .assertLogText("*ERROR* in path POST /some_path/{some_id} 'some_name' -> parameter should be in camelCase")
+        .assertLogText("*ERROR* in path POST /some_path/{some_id} 'some_id' -> path parameter should be in camelCase")
+        .assertLogText("*ERROR* in path POST /some_path/{some_id} 'some_name' -> query parameter should be in camelCase")
         .assertLogText("*ERROR* in path /some_path/{some_id} 'some_path' -> path should be in hyphen-case")
         .assertLogText("BUILD FAILURE");
   }

--- a/specs/options.json
+++ b/specs/options.json
@@ -17,5 +17,8 @@
   "ignoreHeaderXNaming": true,
   "pathNamingConvention": "HyphenCase",
   "parameterNamingConvention": "CamelCase",
-  "propertiesNamingConvention": "CamelCase"
+  "propertiesNamingConvention": "CamelCase",
+  "queryParamNamingConvention": "CamelCase",
+	"pathParamNamingConvention": "HyphenCase",
+	"cookieParamNamingConvention": "CamelCase"
 }


### PR DESCRIPTION
Hi @JFCote!

This PR contains the implementation for the feature we discussed in issue #367.
I verified that the `formDataParamNamingConvention` option wouldn't be necessary. If we specify a form data body, its schema will be under the `propertyNamingConvention` rule.
The `headerParamNamingConvention` also doesn't make sense. The current `headerNamingConvention` option is enough.

Thanks!